### PR TITLE
Refine lexer tokens and enums

### DIFF
--- a/plank/ast_nodes.py
+++ b/plank/ast_nodes.py
@@ -1,129 +1,150 @@
 # --- AST (Abstract Syntax Tree) Nodes ---
 # Classes representing different nodes in our program's syntax tree.
+from dataclasses import dataclass
+from plank.lexer import Token
+
+
 class AST:
-	pass
+        """Base class for all AST nodes."""
+        pass
 
 
+@dataclass(slots=True)
 class Program(AST):
-	def __init__(self, statements):
-		self.statements = statements  # A list of statement nodes
+        statements: list  # List of statement nodes
 
 
+@dataclass(slots=True)
 class BinOp(AST):
-	def __init__(self, left, op, right):
-		self.left = left  # Left-hand side expression
-		self.op = op  # Operator token (+, -, *, etc.)
-		self.right = right  # Right-hand side expression
+        left: AST
+        op: Token
+        right: AST
 
 
+@dataclass(slots=True)
 class UnaryOp(AST):
-	def __init__(self, op, right):
-		self.op = op  # Operator token (e.g., 'not')
-		self.right = right  # Operand
+        op: Token
+        right: AST
 
 
+@dataclass(slots=True)
 class Num(AST):
-	def __init__(self, token):
-		self.token = token
-		self.value = token.value  # The integer value
+        token: Token
+        value: int | None = None
+
+        def __post_init__(self):
+                if self.value is None:
+                        self.value = self.token.value
 
 
+@dataclass(slots=True)
 class String(AST):
-	def __init__(self, token):
-		self.token = token
-		self.value = token.value  # The string value
+        token: Token
+        value: str | None = None
+
+        def __post_init__(self):
+                if self.value is None:
+                        self.value = self.token.value
 
 
+@dataclass(slots=True)
 class Boolean(AST):
-	def __init__(self, token):
-		self.token = token
-		self.value = token.value  # The boolean value (True/False)
+        token: Token
+        value: bool | None = None
+
+        def __post_init__(self):
+                if self.value is None:
+                        self.value = self.token.value
 
 
+@dataclass(slots=True)
 class Var(AST):
-	def __init__(self, token):
-		self.token = token
-		self.value = token.value  # The variable name (string)
+        token: Token
+        value: str | None = None
+
+        def __post_init__(self):
+                if self.value is None:
+                        self.value = self.token.value
 
 
+@dataclass(slots=True)
 class ListLiteral(AST):
-	def __init__(self, elements):
-		self.elements = elements  # A list of AST nodes (expressions)
+        elements: list
 
 
+@dataclass(slots=True)
 class IndexAccess(AST):
-	def __init__(self, list_expr, index_expr):
-		self.list_expr = list_expr  # The expression that evaluates to a list (e.g., a Var node)
-		self.index_expr = index_expr  # The expression that evaluates to the index
+        list_expr: AST
+        index_expr: AST
 
 
+@dataclass(slots=True)
 class ListAssign(AST):
-	def __init__(self, list_var, index_expr, value_expr):
-		self.list_var = list_var  # The Var node representing the list variable
-		self.index_expr = index_expr  # The expression for the index
-		self.value_expr = value_expr  # The expression for the value to assign
+        list_var: Var
+        index_expr: AST
+        value_expr: AST
 
 
+@dataclass(slots=True)
 class Lambda(AST):
-	def __init__(self, params, body, is_curried=False):
-		self.params = params  # List of Var nodes for parameters
-		self.body = body  # AST node for the lambda's body (expression or Program)
-		self.is_curried = is_curried  # Flag for curried function
+        params: list
+        body: AST
+        is_curried: bool = False
 
 
+@dataclass(slots=True)
 class Call(AST):
-	def __init__(self, func_expr, args):
-		self.func_expr = func_expr  # The expression evaluating to the callable
-		self.args = args  # List of AST nodes for arguments
+        func_expr: AST
+        args: list
 
 
+@dataclass(slots=True)
 class Assign(AST):
-	def __init__(self, left, op, right):
-		self.left = left  # The variable (Var node) being assigned to
-		self.op = op  # The ASSIGN token ('<-')
-		self.right = right  # The expression whose value is assigned
+        left: Var
+        op: Token
+        right: AST
 
 
+@dataclass(slots=True)
 class AugmentedAssign(AST):
-	def __init__(self, left, op, right):
-		self.left = left  # The variable (Var node) being assigned to
-		self.op = op  # The augmented assignment token (e.g., '+<-')
-		self.right = right  # The expression whose value is used in the operation
+        left: Var
+        op: Token
+        right: AST
 
 
+@dataclass(slots=True)
 class InputStatement(AST):
-	def __init__(self, variables, type_token):
-		self.variables = variables  # List of Var nodes to store input
-		self.type_token = type_token  # The KEYWORD_INT token
+        variables: list
+        type_token: Token
 
 
+@dataclass(slots=True)
 class OutputStatement(AST):
-	def __init__(self, expressions):  # Now takes a list of expressions
-		self.expressions = expressions  # List of expressions to be printed
+        expressions: list
 
 
+@dataclass(slots=True)
 class ForStatement(AST):
-	def __init__(self, variable, start_expr, end_expr, body):
-		self.variable = variable  # The loop variable (Var node)
-		self.start_expr = start_expr  # Expression for the start of the range
-		self.end_expr = end_expr  # Expression for the end of the range
-		self.body = body  # List of statements in the loop body
+        variable: Var
+        start_expr: AST
+        end_expr: AST
+        body: list
 
 
+@dataclass(slots=True)
 class WhileStatement(AST):
-        def __init__(self, loop_var, condition, body):
-                self.loop_var = loop_var  # The variable for the loop (e.g., 'x')
-                self.condition = condition  # The expression representing the loop condition (e.g., 'x < 5')
-                self.body = body  # List of statements in the loop body
+        loop_var: Var
+        condition: AST
+        body: list
 
 
+@dataclass(slots=True)
 class IfExpression(AST):
-	def __init__(self, condition, then_branch, else_branch=None):
-		self.condition = condition
-		self.then_branch = then_branch
-		self.else_branch = else_branch
+        condition: AST
+        then_branch: AST
+        else_branch: AST | None = None
 
 
-class ExpressionStatement(AST):  # New AST node for expressions treated as statements
-	def __init__(self, expression):
-		self.expression = expression
+@dataclass(slots=True)
+class ExpressionStatement(AST):  # Expression used as a statement
+        expression: AST

--- a/plank/interpreter.py
+++ b/plank/interpreter.py
@@ -1,6 +1,7 @@
 import sys
 
 from plank.token_types import *
+from plank.token_types import TokenType
 from plank.ast_nodes import *
 
 
@@ -84,67 +85,64 @@ class Interpreter:
 		return last_result  # Return the result of the last statement/expression
 	
 	def visit_BinOp(self, node):
-		"""Evaluate binary operations, including string concatenation and multiplication, and logical/comparison operators."""
-		left_val = self.visit(node.left)
-		right_val = self.visit(node.right)
-		
-		if node.op.type == PLUS:
-			if isinstance(left_val, str) and isinstance(right_val, str):
-				return left_val + right_val  # String concatenation
-			elif isinstance(left_val, (int, float)) and isinstance(right_val, (int, float)):
-				return left_val + right_val  # Numeric addition
-			else:
-				raise Exception(
-					f"Runtime error: Cannot perform '+' on types {type(left_val).__name__} and {type(right_val).__name__}")
-		
-		elif node.op.type == MULTIPLY:
-			if isinstance(left_val, str) and isinstance(right_val, int):
-				return left_val * right_val  # String repetition
-			elif isinstance(left_val, int) and isinstance(right_val, str):
-				return right_val * left_val  # String repetition (order doesn't matter)
-			elif isinstance(left_val, (int, float)) and isinstance(right_val, (int, float)):
-				return left_val * right_val  # Numeric multiplication
-			else:
-				raise Exception(
-					f"Runtime error: Cannot perform '*' on types {type(left_val).__name__} and {type(right_val).__name__}")
-		
-		# Logical AND and OR
-		elif node.op.type == KEYWORD_AND:
-			return bool(left_val) and bool(right_val)
-		elif node.op.type == KEYWORD_OR:
-			return bool(left_val) or bool(right_val)
-		
-		# Comparison Operators
-		elif node.op.type == EQ:
-			return left_val == right_val
-		elif node.op.type == NEQ:
-			return left_val != right_val
-		elif node.op.type == LT:
-			return left_val < right_val
-		elif node.op.type == GT:
-			return left_val > right_val
-		elif node.op.type == LTE:
-			return left_val <= right_val
-		elif node.op.type == GTE:
-			return left_val >= right_val
-		
-		# For other arithmetic operations, ensure both are numbers
-		elif not isinstance(left_val, (int, float)) or not isinstance(right_val, (int, float)):
-			raise Exception(
-				f"Runtime error: Cannot perform arithmetic operation '{node.op.value}' on non-numeric types.")
-		
-		elif node.op.type == MINUS:
-			return left_val - right_val
-		elif node.op.type == DIVIDE:
-			if right_val == 0:
-				raise Exception("Runtime error: Division by zero")
-			return left_val / right_val  # Standard float division
-		elif node.op.type == FLOOR_DIVIDE:
-			if right_val == 0:
-				raise Exception("Runtime error: Division by zero")
-			return left_val // right_val  # Integer floor division
-		elif node.op.type == EXPONENT:
-			return left_val ** right_val
+	        """Evaluate binary operations and logical/comparison operators."""
+	        left_val = self.visit(node.left)
+	        right_val = self.visit(node.right)
+
+	        match node.op.type:
+	                case TokenType.PLUS:
+	                        if isinstance(left_val, str) and isinstance(right_val, str):
+	                                return left_val + right_val
+	                        if isinstance(left_val, (int, float)) and isinstance(right_val, (int, float)):
+	                                return left_val + right_val
+	                        raise Exception(
+	                                f"Runtime error: Cannot perform '+' on types {type(left_val).__name__} and {type(right_val).__name__}")
+
+	                case TokenType.MULTIPLY:
+	                        if isinstance(left_val, str) and isinstance(right_val, int):
+	                                return left_val * right_val
+	                        if isinstance(left_val, int) and isinstance(right_val, str):
+	                                return right_val * left_val
+	                        if isinstance(left_val, (int, float)) and isinstance(right_val, (int, float)):
+	                                return left_val * right_val
+	                        raise Exception(
+	                                f"Runtime error: Cannot perform '*' on types {type(left_val).__name__} and {type(right_val).__name__}")
+
+	                case TokenType.KEYWORD_AND:
+	                        return bool(left_val) and bool(right_val)
+	                case TokenType.KEYWORD_OR:
+	                        return bool(left_val) or bool(right_val)
+
+	                case TokenType.EQ:
+	                        return left_val == right_val
+	                case TokenType.NEQ:
+	                        return left_val != right_val
+	                case TokenType.LT:
+	                        return left_val < right_val
+	                case TokenType.GT:
+	                        return left_val > right_val
+	                case TokenType.LTE:
+	                        return left_val <= right_val
+	                case TokenType.GTE:
+	                        return left_val >= right_val
+
+	                case TokenType.MINUS:
+	                        if not isinstance(left_val, (int, float)) or not isinstance(right_val, (int, float)):
+	                                raise Exception(
+	                                        f"Runtime error: Cannot perform arithmetic operation '-' on non-numeric types.")
+	                        return left_val - right_val
+	                case TokenType.DIVIDE:
+	                        if right_val == 0:
+	                                raise Exception("Runtime error: Division by zero")
+	                        return left_val / right_val
+	                case TokenType.FLOOR_DIVIDE:
+	                        if right_val == 0:
+	                                raise Exception("Runtime error: Division by zero")
+	                        return left_val // right_val
+	                case TokenType.EXPONENT:
+	                        return left_val ** right_val
+	                case _:
+	                        raise Exception(f"Runtime error: Unknown binary operator {node.op.value}")
 	
 	def visit_UnaryOp(self, node):
 		"""Evaluate unary operations."""

--- a/plank/token_types.py
+++ b/plank/token_types.py
@@ -1,63 +1,74 @@
-# --- Token Types ---
-# Define constants for all token types our language will recognize.
-EOF = 'EOF'  # End of File
-IDENTIFIER = 'IDENTIFIER'  # Variable names (e.g., 'a', 'b', 'result')
-INTEGER = 'INTEGER'  # Integer literals (e.g., '10', '42')
-STRING = 'STRING'  # String literals (e.g., '"hello"', '" "')
+"""Enumeration of all token types used by the language."""
 
-# Arithmetic Operators
-PLUS = 'PLUS'  # '+'
-MINUS = 'MINUS'  # '-'
-MULTIPLY = 'MULTIPLY'  # '*'
-DIVIDE = 'DIVIDE'  # '/'
-EXPONENT = 'EXPONENT'  # '**'
-FLOOR_DIVIDE = 'FLOOR_DIVIDE'  # '//'
+from enum import StrEnum, auto
 
-# Assignment and Keywords
-ASSIGN = 'ASSIGN'  # '<-'
-KEYWORD_INT = 'KEYWORD_INT'  # 'int' (for input type)
-KEYWORD_OUT = 'KEYWORD_OUT'  # 'out' (for output statement)
 
-# For Loop Keywords and Operators
-KEYWORD_FOR = 'KEYWORD_FOR'  # 'for'
-RANGE_OP = 'RANGE_OP'  # '..'
-ARROW = 'ARROW'  # '->'
+class TokenType(StrEnum):
+    """Enumeration of all token types."""
 
-# Augmented Assignment Operators
-PLUS_ASSIGN = 'PLUS_ASSIGN'  # '+<-'
-MINUS_ASSIGN = 'MINUS_ASSIGN'  # '-<-'
-MULTIPLY_ASSIGN = 'MULTIPLY_ASSIGN'  # '*<-'
-DIVIDE_ASSIGN = 'DIVIDE_ASSIGN'  # '/<-'
-EXPONENT_ASSIGN = 'EXPONENT_ASSIGN'  # '**<-'
-FLOOR_DIVIDE_ASSIGN = 'FLOOR_DIVIDE_ASSIGN'  # '//<-'
+    EOF = auto()  # End of File
+    IDENTIFIER = auto()  # Variable names (e.g., 'a', 'b', 'result')
+    INTEGER = auto()  # Integer literals (e.g., '10', '42')
+    STRING = auto()  # String literals (e.g., '"hello"', '" "')
 
-# Boolean Literals and Logical Operators
-KEYWORD_TRUE = 'KEYWORD_TRUE'  # 'true'
-KEYWORD_FALSE = 'KEYWORD_FALSE'  # 'false'
-KEYWORD_AND = 'KEYWORD_AND'  # 'and'
-KEYWORD_OR = 'KEYWORD_OR'  # 'or'
-KEYWORD_NOT = 'KEYWORD_NOT'  # 'not'
-KEYWORD_WHILE = 'KEYWORD_WHILE'  # 'while'
-KEYWORD_IF = 'KEYWORD_IF'  # 'if'
-KEYWORD_ELSE = 'KEYWORD_ELSE'  # 'else'
-KEYWORD_C = 'KEYWORD_C'  # 'c' for curried functions
+    # Arithmetic Operators
+    PLUS = auto()  # '+'
+    MINUS = auto()  # '-'
+    MULTIPLY = auto()  # '*'
+    DIVIDE = auto()  # '/'
+    EXPONENT = auto()  # '**'
+    FLOOR_DIVIDE = auto()  # '//'
 
-# Comparison Operators
-EQ = 'EQ'  # '=='
-NEQ = 'NEQ'  # '!='
-LT = 'LT'  # '<'
-GT = 'GT'  # '>'
-LTE = 'LTE'  # '<='
-GTE = 'GTE'  # '>='
+    # Assignment and Keywords
+    ASSIGN = auto()  # '<-'
+    KEYWORD_INT = auto()  # 'int' (for input type)
+    KEYWORD_OUT = auto()  # 'out' (for output statement)
 
-# Punctuation
-COMMA = 'COMMA'  # ','
-LPAREN = 'LPAREN'  # '('
-RPAREN = 'RPAREN'  # ')'
-LBRACE = 'LBRACE'  # '{'
-RBRACE = 'RBRACE'  # '}'
-SEMICOLON = 'SEMICOLON'  # ';'
+    # For Loop Keywords and Operators
+    KEYWORD_FOR = auto()  # 'for'
+    RANGE_OP = auto()  # '..'
+    ARROW = auto()  # '->'
 
-# List Punctuation
-LBRACKET = 'LBRACKET'  # '['
-RBRACKET = 'RBRACKET'  # ']'
+    # Augmented Assignment Operators
+    PLUS_ASSIGN = auto()  # '+<-'
+    MINUS_ASSIGN = auto()  # '-<-'
+    MULTIPLY_ASSIGN = auto()  # '*<-'
+    DIVIDE_ASSIGN = auto()  # '/<-'
+    EXPONENT_ASSIGN = auto()  # '**<-'
+    FLOOR_DIVIDE_ASSIGN = auto()  # '//<-'
+
+    # Boolean Literals and Logical Operators
+    KEYWORD_TRUE = auto()  # 'true'
+    KEYWORD_FALSE = auto()  # 'false'
+    KEYWORD_AND = auto()  # 'and'
+    KEYWORD_OR = auto()  # 'or'
+    KEYWORD_NOT = auto()  # 'not'
+    KEYWORD_WHILE = auto()  # 'while'
+    KEYWORD_IF = auto()  # 'if'
+    KEYWORD_ELSE = auto()  # 'else'
+    KEYWORD_C = auto()  # 'c' for curried functions
+
+    # Comparison Operators
+    EQ = auto()  # '=='
+    NEQ = auto()  # '!='
+    LT = auto()  # '<'
+    GT = auto()  # '>'
+    LTE = auto()  # '<='
+    GTE = auto()  # '>='
+
+    # Punctuation
+    COMMA = auto()  # ','
+    LPAREN = auto()  # '('
+    RPAREN = auto()  # ')'
+    LBRACE = auto()  # '{'
+    RBRACE = auto()  # '}'
+    SEMICOLON = auto()  # ';'
+
+    # List Punctuation
+    LBRACKET = auto()  # '['
+    RBRACKET = auto()  # ']'
+
+
+# Export individual names for backwards compatibility
+globals().update(TokenType.__members__)
+__all__ = list(TokenType.__members__)


### PR DESCRIPTION
## Summary
- streamline token enum handling using `StrEnum`
- expose token constants automatically
- convert `Token` to a dataclass with `slots`
- consolidate keyword and single-character token lookups

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b38ad17083279655ce33752eb7a4