### PR TITLE
Add step support to for loops

### DIFF
--- a/plank/ast_nodes.py
+++ b/plank/ast_nodes.py
@@ -130,6 +130,7 @@ class ForStatement(AST):
 	start_expr: AST
 	end_expr: AST
 	body: list
+	step_expr: AST | None = None
 
 
 @dataclass(slots=True)

--- a/plank/tests/test_interpreter.py
+++ b/plank/tests/test_interpreter.py
@@ -31,6 +31,8 @@ class TestPlankExamples(unittest.TestCase):
 			("out <- not true; out <- '\\n'", False),
 			# may just print
 			("(x for 1..3) -> { out <- x out <- ' ' }", None),
+				("(x for 2..10..2) -> { out <- x out <- ' ' }", "2 4 6 8 10 "),
+				("(x for 5..1..-1) -> { out <- x out <- ' ' }", "5 4 3 2 1 "),
 			("x <- 0; (x while x < 5) -> { out <- x; x +<- 1; out <- '\\n' }", None),
 			("my_list <- [10, 'hello', true]; out <- my_list[1]; out <- '\\n'", 'hello'),
 			("my_list <- [10, 'hello', true]; my_list[0] <- 99; out <- my_list[0]; out <- '\n'", 99),


### PR DESCRIPTION
## Summary
- support optional step expression in `for` loops
- allow unary minus in parser and interpreter
- handle step iteration in interpreter
- test stepped loops

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c28bbee08327821ebf72b2bab1b7