### PR TITLE
Refactor lexer and update exports

### DIFF
--- a/plank/lexer.py
+++ b/plank/lexer.py
@@ -3,251 +3,177 @@ from plank.token_types import *
 
 # --- Token Class ---
 # Represents a single token found by the lexer.
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
 class Token:
-	def __init__(self, type, value):
-		self.type = type
-		self.value = value
-	
-	def __str__(self):
-		"""String representation of the Token object."""
-		return f"Token({self.type}, {repr(self.value)})"
-	
-	def __repr__(self):
-		"""Official string representation (for debugging)."""
-		return self.__str__()
+        type: TokenType
+        value: object
+
+        def __repr__(self) -> str:  # pragma: no cover - trivial
+                return f"Token({self.type}, {self.value!r})"
 
 
 # --- Lexer (Tokenizer) ---
 # Reads the input text and converts it into a stream of tokens.
 class Lexer:
-	def __init__(self, text):
-		self.text = text
-		self.pos = 0  # Current position in the input text
-		self.current_char = self.text[self.pos] if self.text else None	# Current character
-	
-	def advance(self):
-		"""Move to the next character in the input text."""
-		self.pos += 1
-		if self.pos < len(self.text):
-			self.current_char = self.text[self.pos]
-		else:
-			self.current_char = None  # Indicates end of input
-	
-	def peek(self, offset=1):
-		"""Look ahead without advancing the position."""
-		peek_pos = self.pos + offset
-		if peek_pos < len(self.text):
-			return self.text[peek_pos]
-		return None
-	
-	def skip_whitespace(self):
-		"""Skip over any whitespace characters."""
-		while self.current_char is not None and self.current_char.isspace():
-			self.advance()
-	
-	def integer(self):
-		"""Parse an integer literal from the input."""
-		result = ''
-		while self.current_char is not None and self.current_char.isdigit():
-			result += self.current_char
-			self.advance()
-		return int(result)
-	
-	def string(self):
-		"""Parse a string literal from the input (enclosed in double or single quotes).
-		Handles escape sequences: \n, \t, \\
-		"""
-		quote_char = self.current_char	# Capture the opening quote character
-		self.advance()	# Consume the opening quote
-		result = ''
-		while self.current_char is not None and self.current_char != quote_char:
-			if self.current_char == '\\':  # Handle escape sequences
-				self.advance()	# Consume the backslash
-				if self.current_char == 'n':
-					result += '\n'
-				elif self.current_char == 't':
-					result += '\t'
-				elif self.current_char == '\\':
-					result += '\\'
-				else:
-					raise Exception(
-						f'Lexer error: Invalid escape sequence \\{self.current_char} at position {self.pos - 1}')
-			else:
-				result += self.current_char
-			self.advance()
-		if self.current_char is None:
-			raise Exception(f'Lexer error: Unclosed string literal starting with {quote_char} at position {self.pos}')
-		self.advance()	# Consume the closing quote
-		return result
-	
-	def _id(self):
-		"""Parse an identifier or keyword."""
-		result = ''
-		while self.current_char is not None and (self.current_char.isalnum() or self.current_char == '_'):
-			result += self.current_char
-			self.advance()
-		keywords = {
-			'int': (KEYWORD_INT, 'int'),
-			'string': (KEYWORD_STRING, 'string'),
-			'bool': (KEYWORD_BOOL, 'bool'),
-			'list': (KEYWORD_LIST, 'list'),
-			'out': (KEYWORD_OUT, 'out'),
-			'for': (KEYWORD_FOR, 'for'),
-			'true': (KEYWORD_TRUE, True),
-			'false': (KEYWORD_FALSE, False),
-			'and': (KEYWORD_AND, 'and'),
-			'or': (KEYWORD_OR, 'or'),
-			'not': (KEYWORD_NOT, 'not'),
-			'while': (KEYWORD_WHILE, 'while'),
-			'if': (KEYWORD_IF, 'if'),
-			'else': (KEYWORD_ELSE, 'else'),
-			'c': (KEYWORD_C, 'c'),
-		}
-		type_val = keywords.get(result)
-		if type_val:
-			return Token(*type_val)
-		return Token(IDENTIFIER, result)
-	
-	def get_next_token(self):
-		"""Get the next token from the input text."""
-		while self.current_char is not None:
-			self.skip_whitespace()	# Always skip whitespace before processing
-			
-			if self.current_char is None:  # Check again after skipping whitespace
-				break
-			
-			if self.current_char.isdigit():
-				return Token(INTEGER, self.integer())
-			
-			if self.current_char == '"' or self.current_char == "'":
-				return Token(STRING, self.string())
-			
-			if self.current_char.isalpha() or self.current_char == '_':
-				return self._id()
-			
-			# Handle multi-character operators and augmented assignments (longest match first)
-			if self.current_char == '*':
-				if self.peek() == '*':
-					self.advance()	# Consume first '*'
-					if self.peek() == '<' and self.peek(2) == '-':
-						self.advance()	# Consume second '*'
-						self.advance()	# Consume '<'
-						self.advance()	# Consume '-'
-						return Token(EXPONENT_ASSIGN, '**<-')
-					self.advance()	# Consume second '*'
-					return Token(EXPONENT, '**')
-				elif self.peek() == '<' and self.peek(2) == '-':
-					self.advance()	# Consume '*'
-					self.advance()	# Consume '<'
-					self.advance()	# Consume '-'
-					return Token(MULTIPLY_ASSIGN, '*<-')
-				self.advance()
-				return Token(MULTIPLY, '*')
-			
-			if self.current_char == '/':
-				if self.peek() == '/':
-					self.advance()	# Consume first '/'
-					if self.peek() == '<' and self.peek(2) == '-':
-						self.advance()	# Consume second '/'
-						self.advance()	# Consume '<'
-						self.advance()	# Consume '-'
-						return Token(FLOOR_DIVIDE_ASSIGN, '//<-')
-					self.advance()	# Consume second '/'
-					return Token(FLOOR_DIVIDE, '//')
-				elif self.peek() == '<' and self.peek(2) == '-':
-					self.advance()	# Consume '/'
-					self.advance()	# Consume '<'
-					self.advance()	# Consume '-'
-					return Token(DIVIDE_ASSIGN, '/<-')
-				self.advance()
-				return Token(DIVIDE, '/')
-			
-			if self.current_char == '<':
-				self.advance()
-				if self.current_char == '-':
-					self.advance()
-					return Token(ASSIGN, '<-')
-				elif self.current_char == '=':
-					self.advance()
-					return Token(LTE, '<=')
-				return Token(LT, '<')
-			
-			if self.current_char == '>':
-				self.advance()
-				if self.current_char == '=':
-					self.advance()
-					return Token(GTE, '>=')
-				return Token(GT, '>')
-			
-			if self.current_char == '=':
-				self.advance()
-				if self.current_char == '=':
-					self.advance()
-					return Token(EQ, '==')
-				raise Exception(f'Lexer error: Invalid character sequence starting with = at position {self.pos - 1}')
-			
-			if self.current_char == '!':
-				self.advance()
-				if self.current_char == '=':
-					self.advance()
-					return Token(NEQ, '!=')
-				raise Exception(f'Lexer error: Invalid character sequence starting with ! at position {self.pos - 1}')
-			
-			if self.current_char == '-':
-				if self.peek() == '>':
-					self.advance()	# Consume '-'
-					self.advance()	# Consume '>'
-					return Token(ARROW, '->')
-				elif self.peek() == '<' and self.peek(2) == '-':
-					self.advance()	# Consume '-'
-					self.advance()	# Consume '<'
-					self.advance()	# Consume '-'
-					return Token(MINUS_ASSIGN, '-<-')
-				self.advance()
-				return Token(MINUS, '-')
-			
-			if self.current_char == '+':
-				if self.peek() == '<' and self.peek(2) == '-':
-					self.advance()	# Consume '+'
-					self.advance()	# Consume '<'
-					self.advance()	# Consume '-'
-					return Token(PLUS_ASSIGN, '+<-')
-				self.advance()
-				return Token(PLUS, '+')
-			
-			if self.current_char == '.':
-				self.advance()
-				if self.current_char == '.':
-					self.advance()
-					return Token(RANGE_OP, '..')
-				raise Exception(f'Lexer error: Invalid character sequence starting with . at position {self.pos - 1}')
-			
-			# Handle single-character operators and punctuation
-			if self.current_char == ',':
-				self.advance()
-				return Token(COMMA, ',')
-			if self.current_char == '(':
-				self.advance()
-				return Token(LPAREN, '(')
-			if self.current_char == ')':
-				self.advance()
-				return Token(RPAREN, ')')
-			if self.current_char == '{':
-				self.advance()
-				return Token(LBRACE, '{')
-			if self.current_char == '}':
-				self.advance()
-				return Token(RBRACE, '}')
-			if self.current_char == ';':
-				self.advance()
-				return Token(SEMICOLON, ';')
-			if self.current_char == '[':
-				self.advance()
-				return Token(LBRACKET, '[')
-			if self.current_char == ']':
-				self.advance()
-				return Token(RBRACKET, ']')
-			
-			# If none of the above, it's an unexpected character
-			raise Exception(f'Lexer error: Invalid character "{self.current_char}" at position {self.pos}')
-		return Token(EOF, None)	 # Return EOF when all input is processed
+        KEYWORDS = {
+                'int': (KEYWORD_INT, 'int'),
+                'string': (KEYWORD_STRING, 'string'),
+                'bool': (KEYWORD_BOOL, 'bool'),
+                'list': (KEYWORD_LIST, 'list'),
+                'out': (KEYWORD_OUT, 'out'),
+                'for': (KEYWORD_FOR, 'for'),
+                'true': (KEYWORD_TRUE, True),
+                'false': (KEYWORD_FALSE, False),
+                'and': (KEYWORD_AND, 'and'),
+                'or': (KEYWORD_OR, 'or'),
+                'not': (KEYWORD_NOT, 'not'),
+                'while': (KEYWORD_WHILE, 'while'),
+                'if': (KEYWORD_IF, 'if'),
+                'else': (KEYWORD_ELSE, 'else'),
+                'c': (KEYWORD_C, 'c'),
+        }
+
+        MULTI_OPS = {
+                '**<-': EXPONENT_ASSIGN,
+                '*<-': MULTIPLY_ASSIGN,
+                '**': EXPONENT,
+                '//<-': FLOOR_DIVIDE_ASSIGN,
+                '/<-': DIVIDE_ASSIGN,
+                '//': FLOOR_DIVIDE,
+                '<-': ASSIGN,
+                '->': ARROW,
+                '-<-': MINUS_ASSIGN,
+                '+<-': PLUS_ASSIGN,
+                '<=': LTE,
+                '>=': GTE,
+                '==': EQ,
+                '!=': NEQ,
+                '..': RANGE_OP,
+        }
+
+        SINGLE_OPS = {
+                '*': MULTIPLY,
+                '/': DIVIDE,
+                '<': LT,
+                '>': GT,
+                '-': MINUS,
+                '+': PLUS,
+                ',': COMMA,
+                '(': LPAREN,
+                ')': RPAREN,
+                '{': LBRACE,
+                '}': RBRACE,
+                ';': SEMICOLON,
+                '[': LBRACKET,
+                ']': RBRACKET,
+        }
+
+        def __init__(self, text):
+                self.text = text
+                self.pos = 0
+                self.current_char = self.text[self.pos] if self.text else None
+        
+        def advance(self):
+                """Move to the next character in the input text."""
+                self.pos += 1
+                if self.pos < len(self.text):
+                        self.current_char = self.text[self.pos]
+                else:
+                        self.current_char = None  # Indicates end of input
+        
+        def match(self, string):
+                """Return True and consume the string if it is next in the input."""
+                if self.text.startswith(string, self.pos):
+                        self.pos += len(string)
+                        self.current_char = self.text[self.pos] if self.pos < len(self.text) else None
+                        return True
+                return False
+        
+        def skip_whitespace(self):
+                """Skip over any whitespace characters."""
+                while self.current_char is not None and self.current_char.isspace():
+                        self.advance()
+        
+        def integer(self):
+                """Parse an integer literal from the input."""
+                result = ''
+                while self.current_char is not None and self.current_char.isdigit():
+                        result += self.current_char
+                        self.advance()
+                return int(result)
+        
+        def string(self):
+                """Parse a string literal from the input (enclosed in double or single quotes).
+                Handles escape sequences: \n, \t, \\
+                """
+                quote_char = self.current_char  # Capture the opening quote character
+                self.advance()  # Consume the opening quote
+                result = ''
+                while self.current_char is not None and self.current_char != quote_char:
+                        if self.current_char == '\\':  # Handle escape sequences
+                                self.advance()  # Consume the backslash
+                                if self.current_char == 'n':
+                                        result += '\n'
+                                elif self.current_char == 't':
+                                        result += '\t'
+                                elif self.current_char == '\\':
+                                        result += '\\'
+                                else:
+                                        raise Exception(
+                                                f'Lexer error: Invalid escape sequence \\{self.current_char} at position {self.pos - 1}')
+                        else:
+                                result += self.current_char
+                        self.advance()
+                if self.current_char is None:
+                        raise Exception(f'Lexer error: Unclosed string literal starting with {quote_char} at position {self.pos}')
+                self.advance()  # Consume the closing quote
+                return result
+        
+        def _id(self):
+                """Parse an identifier or keyword."""
+                result = ''
+                while self.current_char and (self.current_char.isalnum() or self.current_char == '_'):
+                        result += self.current_char
+                        self.advance()
+                return Token(*self.KEYWORDS.get(result, (IDENTIFIER, result)))
+        
+
+        def get_next_token(self):
+                """Return the next token from the input text."""
+                while self.current_char is not None:
+                        self.skip_whitespace()
+                        if self.current_char is None:
+                                break
+
+                        if self.current_char.isdigit():
+                                return Token(INTEGER, self.integer())
+
+                        if self.current_char in ('"', "'"):
+                                return Token(STRING, self.string())
+
+                        if self.current_char.isalpha() or self.current_char == '_':
+                                return self._id()
+
+                        for op, ttype in self.MULTI_OPS.items():
+                                if self.match(op):
+                                        return Token(ttype, op)
+
+                        if self.current_char == '.':
+                                raise Exception(
+                                        f'Lexer error: Invalid character sequence starting with . at position {self.pos}'
+                                )
+
+                        token_type = self.SINGLE_OPS.get(self.current_char)
+                        if token_type:
+                                ch = self.current_char
+                                self.advance()
+                                return Token(token_type, ch)
+
+                        raise Exception(
+                                f'Lexer error: Invalid character {self.current_char!r} at position {self.pos}'
+                        )
+
+                return Token(EOF, None)

--- a/plank/token_types.py
+++ b/plank/token_types.py
@@ -73,53 +73,7 @@ class TokenType(Enum):
 
 
 # Export individual names for backwards compatibility
-EOF = TokenType.EOF
-IDENTIFIER = TokenType.IDENTIFIER
-INTEGER = TokenType.INTEGER
-STRING = TokenType.STRING
-PLUS = TokenType.PLUS
-MINUS = TokenType.MINUS
-MULTIPLY = TokenType.MULTIPLY
-DIVIDE = TokenType.DIVIDE
-EXPONENT = TokenType.EXPONENT
-FLOOR_DIVIDE = TokenType.FLOOR_DIVIDE
-ASSIGN = TokenType.ASSIGN
-KEYWORD_INT = TokenType.KEYWORD_INT
-KEYWORD_STRING = TokenType.KEYWORD_STRING
-KEYWORD_BOOL = TokenType.KEYWORD_BOOL
-KEYWORD_LIST = TokenType.KEYWORD_LIST
-KEYWORD_OUT = TokenType.KEYWORD_OUT
-KEYWORD_FOR = TokenType.KEYWORD_FOR
-RANGE_OP = TokenType.RANGE_OP
-ARROW = TokenType.ARROW
-PLUS_ASSIGN = TokenType.PLUS_ASSIGN
-MINUS_ASSIGN = TokenType.MINUS_ASSIGN
-MULTIPLY_ASSIGN = TokenType.MULTIPLY_ASSIGN
-DIVIDE_ASSIGN = TokenType.DIVIDE_ASSIGN
-EXPONENT_ASSIGN = TokenType.EXPONENT_ASSIGN
-FLOOR_DIVIDE_ASSIGN = TokenType.FLOOR_DIVIDE_ASSIGN
-KEYWORD_TRUE = TokenType.KEYWORD_TRUE
-KEYWORD_FALSE = TokenType.KEYWORD_FALSE
-KEYWORD_AND = TokenType.KEYWORD_AND
-KEYWORD_OR = TokenType.KEYWORD_OR
-KEYWORD_NOT = TokenType.KEYWORD_NOT
-KEYWORD_WHILE = TokenType.KEYWORD_WHILE
-KEYWORD_IF = TokenType.KEYWORD_IF
-KEYWORD_ELSE = TokenType.KEYWORD_ELSE
-KEYWORD_C = TokenType.KEYWORD_C
-EQ = TokenType.EQ
-NEQ = TokenType.NEQ
-LT = TokenType.LT
-GT = TokenType.GT
-LTE = TokenType.LTE
-GTE = TokenType.GTE
-COMMA = TokenType.COMMA
-LPAREN = TokenType.LPAREN
-RPAREN = TokenType.RPAREN
-LBRACE = TokenType.LBRACE
-RBRACE = TokenType.RBRACE
-SEMICOLON = TokenType.SEMICOLON
-LBRACKET = TokenType.LBRACKET
-RBRACKET = TokenType.RBRACKET
+for _token in TokenType:
+    globals()[_token.name] = _token
 
-__all__ = [name for name in globals() if name.isupper()]
+__all__ = ['TokenType', *TokenType.__members__]


### PR DESCRIPTION
## Summary
- implement `Token` as a dataclass
- consolidate lexer tables for keywords and operators
- export `TokenType` in `token_types`

## Testing
- `pytest -q plank/tests/test_interpreter.py`

------
https://chatgpt.com/codex/tasks/task_e_68421297e6d883278db2e0fe81d4f49a