### PR TITLE
Add builtin functions with optional parentheses

### DIFF
--- a/plank/interpreter.py
+++ b/plank/interpreter.py
@@ -8,448 +8,495 @@ from plank.token_types import TokenType
 # --- Interpreter ---
 # Represents a callable function created from a Lambda AST node.
 class Callable:
-	def __init__(self, params, body, closure_env, is_curried=False, applied_args=None):
-		self.params = params
-		self.body = body
-		self.closure_env = closure_env	# The scope where the lambda was defined
-		self.is_curried = is_curried
-		self.applied_args = applied_args if applied_args is not None else []
-	
-	def __str__(self):
-		curry_str = " (curried)" if self.is_curried else ""
-		applied_str = f" (applied: {len(self.applied_args)}/{len(self.params)})" if self.applied_args else ""
-		return f"<lambda{curry_str} with params {', '.join(p.value for p in self.params)}{applied_str}>"
-	
-	__repr__ = __str__
+    def __init__(self, params, body, closure_env, is_curried=False, applied_args=None):
+        self.params = params
+        self.body = body
+        self.closure_env = closure_env  # The scope where the lambda was defined
+        self.is_curried = is_curried
+        self.applied_args = applied_args if applied_args is not None else []
+    
+    def __str__(self):
+        curry_str = " (curried)" if self.is_curried else ""
+        applied_str = f" (applied: {len(self.applied_args)}/{len(self.params)})" if self.applied_args else ""
+        return f"<lambda{curry_str} with params {', '.join(p.value for p in self.params)}{applied_str}>"
+    
+    __repr__ = __str__
 
 
 # Traverses the AST and executes the program.
 class Interpreter:
-	def __init__(self, parser=None):
-		self.parser = parser
-		self.scopes = [{}]  # List of dictionaries, each dict is a scope. Global scope is the first.
-	
-	@property
-	def current_scope(self):
-		# Returns the innermost (current) scope
-		return self.scopes[-1]
-	
-	def enter_scope(self):
-		# Pushes a new empty scope onto the stack
-		self.scopes.append({})
-	
-	def exit_scope(self):
-		# Pops the current scope from the stack, but not the global scope
-		if len(self.scopes) > 1:
-			self.scopes.pop()
-		else:
-			raise Exception("Runtime error: Attempted to exit global scope.")
-	
-	def assign_variable(self, name, value):
-		# Assigns to the nearest enclosing scope where variable is found,
-		# otherwise creates it in the current (innermost) scope.
-		for scope in reversed(self.scopes):
-			if name in scope:
-				scope[name] = value
-				return
-		self.current_scope[name] = value  # Create in current scope if not found
-	
-	def lookup_variable(self, name):
-		# Looks up variable from current scope outwards to the global scope.
-		for scope in reversed(self.scopes):
-			if name in scope:
-				return scope[name]
-		raise Exception(f"Runtime error: Undefined variable '{name}'")
-	
-	def visit(self, node):
-		"""
-		Generic visitor method to dispatch to specific visit_ methods
-		based on the AST node's type.
-		"""
-		method_name = f'visit_{type(node).__name__}'
-		visitor = getattr(self, method_name, self.generic_visit)
-		return visitor(node)
-	
-	def generic_visit(self, node):
-		"""Fallback for unhandled AST node types."""
-		raise Exception(f'No visit_{type(node).__name__} method defined for interpreter.')
-	
-	def visit_Program(self, node):
-		"""Visit all statements in the program."""
-		last_result = None
-		for statement in node.statements:
-			stmt_result = self.visit(statement)
-			# For implicit return: if the last statement is an expression, its value is the return.
-			# If it's an assignment or output, it might return None.
-			last_result = stmt_result
-		return last_result  # Return the result of the last statement/expression
-	
-	def visit_BinOp(self, node):
-		"""Evaluate binary operations and logical/comparison operators."""
-		left_val = self.visit(node.left)
-		right_val = self.visit(node.right)
-		
-		match node.op.type:
-			case TokenType.PLUS:
-				if isinstance(left_val, str) and isinstance(right_val, str):
-					return left_val + right_val
-				if isinstance(left_val, (int, float)) and isinstance(right_val, (int, float)):
-					return left_val + right_val
-				raise Exception(
-					f"Runtime error: Cannot perform '+' on types {type(left_val).__name__} and {type(right_val).__name__}")
-			
-			case TokenType.MULTIPLY:
-				if isinstance(left_val, str) and isinstance(right_val, int):
-					return left_val * right_val
-				if isinstance(left_val, int) and isinstance(right_val, str):
-					return right_val * left_val
-				if isinstance(left_val, (int, float)) and isinstance(right_val, (int, float)):
-					return left_val * right_val
-				raise Exception(
-					f"Runtime error: Cannot perform '*' on types {type(left_val).__name__} and {type(right_val).__name__}")
-			
-			case TokenType.KEYWORD_AND:
-				return bool(left_val) and bool(right_val)
-			case TokenType.KEYWORD_OR:
-				return bool(left_val) or bool(right_val)
-			
-			case TokenType.EQ:
-				return left_val == right_val
-			case TokenType.NEQ:
-				return left_val != right_val
-			case TokenType.LT:
-				return left_val < right_val
-			case TokenType.GT:
-				return left_val > right_val
-			case TokenType.LTE:
-				return left_val <= right_val
-			case TokenType.GTE:
-				return left_val >= right_val
-			
-			case TokenType.MINUS:
-				if not isinstance(left_val, (int, float)) or not isinstance(right_val, (int, float)):
-					raise Exception(
-						f"Runtime error: Cannot perform arithmetic operation '-' on non-numeric types.")
-				return left_val - right_val
-			case TokenType.DIVIDE:
-				if right_val == 0:
-					raise Exception("Runtime error: Division by zero")
-				return left_val / right_val
-			case TokenType.FLOOR_DIVIDE:
-				if right_val == 0:
-					raise Exception("Runtime error: Division by zero")
-				return left_val // right_val
-			case TokenType.EXPONENT:
-				return left_val ** right_val
-			case _:
-				raise Exception(f"Runtime error: Unknown binary operator {node.op.value}")
-	
-	def visit_UnaryOp(self, node):
-		"""Evaluate unary operations."""
-		right_val = self.visit(node.right)
-		if node.op.type == KEYWORD_NOT:
-			return not bool(right_val)
-		elif node.op.type == MINUS:
-			if not isinstance(right_val, (int, float)):
-				raise Exception("Runtime error: Unary minus requires a numeric operand.")
-			return -right_val
-		else:
-			raise Exception(f"Runtime error: Unknown unary operator {node.op.value}")
-	
-	def visit_Num(self, node):
-		"""Return the value of a number literal."""
-		return node.value
-	
-	def visit_String(self, node):
-		"""Return the value of a string literal."""
-		return node.value
-	
-	def visit_Boolean(self, node):
-		"""Return the value of a boolean literal."""
-		return node.value
-	
-	def visit_Var(self, node):
-		"""Retrieve the value of a variable from the current scope chain."""
-		return self.lookup_variable(node.value)
-	
-	def visit_ListLiteral(self, node):
-		"""Evaluate a list literal by evaluating its elements."""
-		return [self.visit(element_expr) for element_expr in node.elements]
-	
-	def visit_IndexAccess(self, node):
-		"""Access an element in a list using an index."""
-		list_obj = self.visit(node.list_expr)
-		index_val = self.visit(node.index_expr)
-		
-		if not isinstance(list_obj, list):
-			raise Exception(f"Runtime error: Cannot index non-list type {type(list_obj).__name__}.")
-		if not isinstance(index_val, int):
-			raise Exception(f"Runtime error: List index must be an integer, got {type(index_val).__name__}.")
-		
-		try:
-			return list_obj[index_val]
-		except IndexError:
-			raise Exception(f"Runtime error: List index {index_val} out of bounds for list of size {len(list_obj)}.")
-	
-	def visit_ListAssign(self, node):
-		"""Assign a value to an element at a specific index in a list."""
-		list_var_name = node.list_var.value
-		# Lookup the list object using the scope chain
-		list_obj = self.lookup_variable(list_var_name)
-		
-		if not isinstance(list_obj, list):
-			raise Exception(f"Runtime error: Cannot assign to index of non-list variable '{list_var_name}'.")
-		
-		index_val = self.visit(node.index_expr)
-		value_to_assign = self.visit(node.value_expr)
-		
-		if not isinstance(index_val, int):
-			raise Exception(f"Runtime error: List index must be an integer, got {type(index_val).__name__}.")
-		
-		try:
-			list_obj[index_val] = value_to_assign
-		except IndexError:
-			raise Exception(
-				f"Runtime error: List index {index_val} out of bounds for "
-				f"list of size {len(list_obj)} during assignment."
-			)
-	
-	def visit_Lambda(self, node):
-		"""
-		When a Lambda node is visited, create a Callable object.
-		Crucially, capture the current scope for closure.
-		"""
-		# A copy of the current scope stack is taken to form the closure environment.
-		# This allows the lambda to access variables from where it was defined.
-		closure_env = list(self.scopes)	 # Create a copy of the scope stack
-		return Callable(node.params, node.body, closure_env, is_curried=node.is_curried)
-	
-	def visit_Call(self, node):
-		"""
-		Execute a function call.
-		"""
-		func_obj = self.visit(node.func_expr)
-		
-		if not isinstance(func_obj, Callable):
-			raise Exception(f"Runtime error: Cannot call non-callable object {func_obj}.")
-		
-		evaluated_new_args = [self.visit(arg_expr) for arg_expr in node.args]
-		combined_args = func_obj.applied_args + evaluated_new_args
-		
-		if func_obj.is_curried and len(combined_args) < len(func_obj.params):
-			# Return a new partially applied callable
-			return Callable(func_obj.params, func_obj.body, func_obj.closure_env,
-					is_curried=True, applied_args=combined_args)
-		
-		if len(combined_args) != len(func_obj.params):
-			raise Exception(
-				f"Runtime error: Expected {len(func_obj.params)} arguments, got {len(combined_args)} for lambda call.")
-		
-		# Save current scope stack
-		original_scopes = list(self.scopes)
-		
-		# Set scopes to the closure environment + a new local scope for the function call
-		self.scopes = list(func_obj.closure_env)  # Start with the closure env
-		self.enter_scope()  # Add a new local scope for function parameters and local vars
-		
-		# Map arguments to parameters in the new function's local scope
-		for param_node, arg_val in zip(func_obj.params, combined_args):
-			self.current_scope[param_node.value] = arg_val
-		
-		result = None
-		try:
-			if isinstance(func_obj.body, Program):	# If body is a block of statements
-				# Execute each statement in the block
-				# The result of the last expression in the block is the return value
-				for statement in func_obj.body.statements:
-					result = self.visit(statement)	# Update result with each statement's return
-			else:  # Body is a single expression
-				result = self.visit(func_obj.body)
-		finally:
-			# Restore the original scope stack regardless of errors
-			self.scopes = original_scopes
-		
-		return result
-	
-	def visit_Assign(self, node):
-		"""Assign the result of an expression to a variable."""
-		var_name = node.left.value
-		self.assign_variable(var_name, self.visit(node.right))
-	
-	def visit_AugmentedAssign(self, node):
-		"""Perform augmented assignment (e.g., a +<- 3)."""
-		var_name = node.left.value
-		try:
-			current_val = self.lookup_variable(var_name)  # Use lookup_variable
-		except Exception:
-			current_val = 0
-		expr_val = self.visit(node.right)
-		
-		# Perform the operation based on the augmented assignment type
-		new_val = None
-		if node.op.type == PLUS_ASSIGN:
-			new_val = current_val + expr_val
-		elif node.op.type == MINUS_ASSIGN:
-			new_val = current_val - expr_val
-		elif node.op.type == MULTIPLY_ASSIGN:
-			# Handle string repetition for augmented multiplication
-			if isinstance(current_val, str) and isinstance(expr_val, int):
-				new_val = current_val * expr_val
-			elif isinstance(current_val, int) and isinstance(expr_val, str):
-				new_val = current_val * expr_val
-			elif isinstance(current_val, (int, float)) and isinstance(expr_val, (int, float)):
-				new_val = current_val * expr_val
-			else:
-				raise Exception(
-					f"Runtime error: Cannot perform '*<-' on types {type(current_val).__name__} and {type(expr_val).__name__}")
-		elif node.op.type == DIVIDE_ASSIGN:
-			if expr_val == 0: raise Exception("Runtime error: Division by zero")
-			new_val = current_val / expr_val
-		elif node.op.type == FLOOR_DIVIDE_ASSIGN:
-			if expr_val == 0: raise Exception("Runtime error: Division by zero")
-			new_val = current_val // expr_val
-		elif node.op.type == EXPONENT_ASSIGN:
-			new_val = current_val ** expr_val
-		else:
-			raise Exception(f"Runtime error: Unknown augmented assignment operator {node.op.value}")
-		
-		self.assign_variable(var_name, new_val)	 # Use assign_variable
-	
-	def visit_InputStatement(self, node):
-		"""
-		Handle input for any supported type. Values are whitespace separated
-		similar to C++'s cin operator.
-		"""
-		try:
-			input_line = input()
-			if node.type_token.value == 'list' and len(node.variables) == 1:
-				parts = [input_line.strip()]
-			else:
-				parts = input_line.strip().split()
-		except EOFError:
-			raise Exception("Runtime error: Unexpected end of input during input statement.")
+    def __init__(self, parser=None):
+        self.parser = parser
+        self.scopes = [{}]  # List of dictionaries, each dict is a scope. Global scope is the first.
+        self._setup_builtins()
 
-		if len(parts) != len(node.variables):
-			raise Exception(
-				f"Runtime error: Expected {len(node.variables)} inputs, but received {len(parts)}.")
+    def _setup_builtins(self):
+        def b_len(x):
+            return len(x)
 
-		def convert(val: str):
-			t = node.type_token.value
-			if t == 'int':
-				return int(val)
-			if t == 'string':
-				return val
-			if t == 'bool':
-				if val.lower() in ('true', '1', 't'):
-					return True
-				if val.lower() in ('false', '0', 'f'):
-					return False
-				raise ValueError
-			if t == 'list':
-				import ast
-				return ast.literal_eval(val)
-			return val
+        def b_head(lst):
+            if not isinstance(lst, list):
+                raise Exception("Runtime error: head expects a list")
+            if not lst:
+                raise Exception("Runtime error: head of empty list")
+            return lst[0]
 
-		try:
-			input_values = [convert(p) for p in parts]
-		except (ValueError, SyntaxError):
-			raise Exception(f"Runtime error: Invalid input for type {node.type_token.value}.")
+        def b_tail(lst):
+            if not isinstance(lst, list):
+                raise Exception("Runtime error: tail expects a list")
+            return lst[1:]
 
-		for i, var_node in enumerate(node.variables):
-			self.assign_variable(var_node.value, input_values[i])
+        def b_abs(x):
+            if not isinstance(x, (int, float)):
+                raise Exception("Runtime error: abs expects a number")
+            return abs(x)
 
-	def visit_TypeCast(self, node):
-		value = self.visit(node.expr)
-		t = node.type_token.value
-		try:
-			if t == 'int':
-				return int(value)
-			if t == 'string':
-				return str(value)
-			if t == 'bool':
-				return bool(value)
-			if t == 'list':
-				return list(value)
-		except Exception:
-			raise Exception(f"Runtime error: Cannot convert to {t}.")
-		raise Exception(f"Runtime error: Unknown type {t} in cast")
-	
-	def visit_OutputStatement(self, node):
-		"""
-		Handle output: evaluate all expressions and print their values to stdout
-		without newlines, supporting chaining.
-		"""
-		for expr in node.expressions:
-			value = self.visit(expr)
-			sys.stdout.write(str(value))
-	
-	def visit_ForStatement(self, node):
-		"""
-		Handle for loop execution.
-		Loops from start_expr to end_expr (inclusive), assigning the current
-		iteration value to the loop variable and executing the body statements.
-		"""
-		loop_var_name = node.variable.value
-		start_val = self.visit(node.start_expr)
-		end_val = self.visit(node.end_expr)
-		step_val = self.visit(node.step_expr) if node.step_expr is not None else (1 if start_val <= end_val else -1)
-		
-		if not isinstance(start_val, int) or not isinstance(end_val, int) or not isinstance(step_val, int):
-			raise Exception("Runtime error: For loop range must be integers.")
-		
-		# Enter a new scope for the loop body
-		self.enter_scope()
-		
-		try:
-			stop = end_val + (1 if step_val > 0 else -1)
-			for i in range(start_val, stop, step_val):
-				self.current_scope[loop_var_name] = i  # Loop var specific to this scope
-				for statement in node.body:
-					self.visit(statement)
-		finally:
-			self.exit_scope()  # Ensure scope is exited even if error occurs
-	
-	def visit_WhileStatement(self, node):
-		"""
-		Handle while loop execution.
-		The loop continues as long as the condition evaluates to true.
-		The loop variable (from `loop_var`) is assumed to be defined in an outer scope
-		and modified within the body.
-		"""
-		# No new scope is entered for the while loop itself; its condition and body run
-		# in the same scope as where the while loop statement itself is defined.
-		# The variable used in the loop (e.g., 'x' in 'x while x < 5') is not local to the loop.
-		
-		while True:
-			condition_result = self.visit(node.condition)
-			
-			if not isinstance(condition_result, bool):
-				raise Exception("Runtime error: While loop condition must evaluate to a boolean.")
-			
-			if not condition_result:
-				break  # Exit loop if condition is false
-			
-			# Execute loop body
-			for statement in node.body:
-				self.visit(statement)
-	
-	def visit_IfExpression(self, node):
-		condition_val = self.visit(node.condition)
-		if condition_val:
-			return self.visit(node.then_branch)
-		elif node.else_branch is not None:
-			return self.visit(node.else_branch)
-		else:
-			return None
-	
-	def visit_ExpressionStatement(self, node):  # New: Visit method for ExpressionStatement
-		"""Evaluates the expression within an ExpressionStatement."""
-		return self.visit(node.expression)
-	
-	def interpret(self):
-		"""Start the interpretation process by parsing the program and visiting its AST."""
-		if self.parser:
-			tree = self.parser.program()
-			self.visit(tree)  # Start traversing the AST from the root (Program node)
-		else:
-			raise Exception("Interpreter error: No parser set.")
+        def b_min(a, b):
+            return a if a < b else b
+
+        def b_max(a, b):
+            return a if a > b else b
+
+        def b_clamp(x, lo, hi):
+            if not all(isinstance(v, (int, float)) for v in (x, lo, hi)):
+                raise Exception("Runtime error: clamp expects numeric arguments")
+            return max(lo, min(x, hi))
+
+        builtins = {
+            'len': b_len,
+            'head': b_head,
+            'tail': b_tail,
+            'abs': b_abs,
+            'min': b_min,
+            'max': b_max,
+            'clamp': b_clamp,
+        }
+        self.scopes[0].update(builtins)
+    
+    @property
+    def current_scope(self):
+        # Returns the innermost (current) scope
+        return self.scopes[-1]
+    
+    def enter_scope(self):
+        # Pushes a new empty scope onto the stack
+        self.scopes.append({})
+    
+    def exit_scope(self):
+        # Pops the current scope from the stack, but not the global scope
+        if len(self.scopes) > 1:
+            self.scopes.pop()
+        else:
+            raise Exception("Runtime error: Attempted to exit global scope.")
+    
+    def assign_variable(self, name, value):
+        # Assigns to the nearest enclosing scope where variable is found,
+        # otherwise creates it in the current (innermost) scope.
+        for scope in reversed(self.scopes):
+            if name in scope:
+                scope[name] = value
+                return
+        self.current_scope[name] = value  # Create in current scope if not found
+    
+    def lookup_variable(self, name):
+        # Looks up variable from current scope outwards to the global scope.
+        for scope in reversed(self.scopes):
+            if name in scope:
+                return scope[name]
+        raise Exception(f"Runtime error: Undefined variable '{name}'")
+    
+    def visit(self, node):
+        """
+        Generic visitor method to dispatch to specific visit_ methods
+        based on the AST node's type.
+        """
+        method_name = f'visit_{type(node).__name__}'
+        visitor = getattr(self, method_name, self.generic_visit)
+        return visitor(node)
+    
+    def generic_visit(self, node):
+        """Fallback for unhandled AST node types."""
+        raise Exception(f'No visit_{type(node).__name__} method defined for interpreter.')
+    
+    def visit_Program(self, node):
+        """Visit all statements in the program."""
+        last_result = None
+        for statement in node.statements:
+            stmt_result = self.visit(statement)
+            # For implicit return: if the last statement is an expression, its value is the return.
+            # If it's an assignment or output, it might return None.
+            last_result = stmt_result
+        return last_result  # Return the result of the last statement/expression
+    
+    def visit_BinOp(self, node):
+        """Evaluate binary operations and logical/comparison operators."""
+        left_val = self.visit(node.left)
+        right_val = self.visit(node.right)
+        
+        match node.op.type:
+            case TokenType.PLUS:
+                if isinstance(left_val, str) and isinstance(right_val, str):
+                    return left_val + right_val
+                if isinstance(left_val, (int, float)) and isinstance(right_val, (int, float)):
+                    return left_val + right_val
+                raise Exception(
+                    f"Runtime error: Cannot perform '+' on types {type(left_val).__name__} and {type(right_val).__name__}")
+            
+            case TokenType.MULTIPLY:
+                if isinstance(left_val, str) and isinstance(right_val, int):
+                    return left_val * right_val
+                if isinstance(left_val, int) and isinstance(right_val, str):
+                    return right_val * left_val
+                if isinstance(left_val, (int, float)) and isinstance(right_val, (int, float)):
+                    return left_val * right_val
+                raise Exception(
+                    f"Runtime error: Cannot perform '*' on types {type(left_val).__name__} and {type(right_val).__name__}")
+            
+            case TokenType.KEYWORD_AND:
+                return bool(left_val) and bool(right_val)
+            case TokenType.KEYWORD_OR:
+                return bool(left_val) or bool(right_val)
+            
+            case TokenType.EQ:
+                return left_val == right_val
+            case TokenType.NEQ:
+                return left_val != right_val
+            case TokenType.LT:
+                return left_val < right_val
+            case TokenType.GT:
+                return left_val > right_val
+            case TokenType.LTE:
+                return left_val <= right_val
+            case TokenType.GTE:
+                return left_val >= right_val
+            
+            case TokenType.MINUS:
+                if not isinstance(left_val, (int, float)) or not isinstance(right_val, (int, float)):
+                    raise Exception(
+                        f"Runtime error: Cannot perform arithmetic operation '-' on non-numeric types.")
+                return left_val - right_val
+            case TokenType.DIVIDE:
+                if right_val == 0:
+                    raise Exception("Runtime error: Division by zero")
+                return left_val / right_val
+            case TokenType.FLOOR_DIVIDE:
+                if right_val == 0:
+                    raise Exception("Runtime error: Division by zero")
+                return left_val // right_val
+            case TokenType.EXPONENT:
+                return left_val ** right_val
+            case _:
+                raise Exception(f"Runtime error: Unknown binary operator {node.op.value}")
+    
+    def visit_UnaryOp(self, node):
+        """Evaluate unary operations."""
+        right_val = self.visit(node.right)
+        if node.op.type == KEYWORD_NOT:
+            return not bool(right_val)
+        elif node.op.type == MINUS:
+            if not isinstance(right_val, (int, float)):
+                raise Exception("Runtime error: Unary minus requires a numeric operand.")
+            return -right_val
+        else:
+            raise Exception(f"Runtime error: Unknown unary operator {node.op.value}")
+    
+    def visit_Num(self, node):
+        """Return the value of a number literal."""
+        return node.value
+    
+    def visit_String(self, node):
+        """Return the value of a string literal."""
+        return node.value
+    
+    def visit_Boolean(self, node):
+        """Return the value of a boolean literal."""
+        return node.value
+    
+    def visit_Var(self, node):
+        """Retrieve the value of a variable from the current scope chain."""
+        return self.lookup_variable(node.value)
+    
+    def visit_ListLiteral(self, node):
+        """Evaluate a list literal by evaluating its elements."""
+        return [self.visit(element_expr) for element_expr in node.elements]
+    
+    def visit_IndexAccess(self, node):
+        """Access an element in a list using an index."""
+        list_obj = self.visit(node.list_expr)
+        index_val = self.visit(node.index_expr)
+        
+        if not isinstance(list_obj, list):
+            raise Exception(f"Runtime error: Cannot index non-list type {type(list_obj).__name__}.")
+        if not isinstance(index_val, int):
+            raise Exception(f"Runtime error: List index must be an integer, got {type(index_val).__name__}.")
+        
+        try:
+            return list_obj[index_val]
+        except IndexError:
+            raise Exception(f"Runtime error: List index {index_val} out of bounds for list of size {len(list_obj)}.")
+    
+    def visit_ListAssign(self, node):
+        """Assign a value to an element at a specific index in a list."""
+        list_var_name = node.list_var.value
+        # Lookup the list object using the scope chain
+        list_obj = self.lookup_variable(list_var_name)
+        
+        if not isinstance(list_obj, list):
+            raise Exception(f"Runtime error: Cannot assign to index of non-list variable '{list_var_name}'.")
+        
+        index_val = self.visit(node.index_expr)
+        value_to_assign = self.visit(node.value_expr)
+        
+        if not isinstance(index_val, int):
+            raise Exception(f"Runtime error: List index must be an integer, got {type(index_val).__name__}.")
+        
+        try:
+            list_obj[index_val] = value_to_assign
+        except IndexError:
+            raise Exception(
+                f"Runtime error: List index {index_val} out of bounds for "
+                f"list of size {len(list_obj)} during assignment."
+            )
+    
+    def visit_Lambda(self, node):
+        """
+        When a Lambda node is visited, create a Callable object.
+        Crucially, capture the current scope for closure.
+        """
+        # A copy of the current scope stack is taken to form the closure environment.
+        # This allows the lambda to access variables from where it was defined.
+        closure_env = list(self.scopes)  # Create a copy of the scope stack
+        return Callable(node.params, node.body, closure_env, is_curried=node.is_curried)
+    
+    def visit_Call(self, node):
+        """
+        Execute a function call.
+        """
+        func_obj = self.visit(node.func_expr)
+
+        evaluated_new_args = [self.visit(arg_expr) for arg_expr in node.args]
+
+        if callable(func_obj) and not isinstance(func_obj, Callable):
+            return func_obj(*evaluated_new_args)
+
+        if not isinstance(func_obj, Callable):
+            raise Exception(f"Runtime error: Cannot call non-callable object {func_obj}.")
+        combined_args = func_obj.applied_args + evaluated_new_args
+        
+        if func_obj.is_curried and len(combined_args) < len(func_obj.params):
+            # Return a new partially applied callable
+            return Callable(func_obj.params, func_obj.body, func_obj.closure_env,
+                    is_curried=True, applied_args=combined_args)
+        
+        if len(combined_args) != len(func_obj.params):
+            raise Exception(
+                f"Runtime error: Expected {len(func_obj.params)} arguments, got {len(combined_args)} for lambda call.")
+        
+        # Save current scope stack
+        original_scopes = list(self.scopes)
+        
+        # Set scopes to the closure environment + a new local scope for the function call
+        self.scopes = list(func_obj.closure_env)  # Start with the closure env
+        self.enter_scope()  # Add a new local scope for function parameters and local vars
+        
+        # Map arguments to parameters in the new function's local scope
+        for param_node, arg_val in zip(func_obj.params, combined_args):
+            self.current_scope[param_node.value] = arg_val
+        
+        result = None
+        try:
+            if isinstance(func_obj.body, Program):  # If body is a block of statements
+                # Execute each statement in the block
+                # The result of the last expression in the block is the return value
+                for statement in func_obj.body.statements:
+                    result = self.visit(statement)  # Update result with each statement's return
+            else:  # Body is a single expression
+                result = self.visit(func_obj.body)
+        finally:
+            # Restore the original scope stack regardless of errors
+            self.scopes = original_scopes
+        
+        return result
+    
+    def visit_Assign(self, node):
+        """Assign the result of an expression to a variable."""
+        var_name = node.left.value
+        self.assign_variable(var_name, self.visit(node.right))
+    
+    def visit_AugmentedAssign(self, node):
+        """Perform augmented assignment (e.g., a +<- 3)."""
+        var_name = node.left.value
+        try:
+            current_val = self.lookup_variable(var_name)  # Use lookup_variable
+        except Exception:
+            current_val = 0
+        expr_val = self.visit(node.right)
+        
+        # Perform the operation based on the augmented assignment type
+        new_val = None
+        if node.op.type == PLUS_ASSIGN:
+            new_val = current_val + expr_val
+        elif node.op.type == MINUS_ASSIGN:
+            new_val = current_val - expr_val
+        elif node.op.type == MULTIPLY_ASSIGN:
+            # Handle string repetition for augmented multiplication
+            if isinstance(current_val, str) and isinstance(expr_val, int):
+                new_val = current_val * expr_val
+            elif isinstance(current_val, int) and isinstance(expr_val, str):
+                new_val = current_val * expr_val
+            elif isinstance(current_val, (int, float)) and isinstance(expr_val, (int, float)):
+                new_val = current_val * expr_val
+            else:
+                raise Exception(
+                    f"Runtime error: Cannot perform '*<-' on types {type(current_val).__name__} and {type(expr_val).__name__}")
+        elif node.op.type == DIVIDE_ASSIGN:
+            if expr_val == 0: raise Exception("Runtime error: Division by zero")
+            new_val = current_val / expr_val
+        elif node.op.type == FLOOR_DIVIDE_ASSIGN:
+            if expr_val == 0: raise Exception("Runtime error: Division by zero")
+            new_val = current_val // expr_val
+        elif node.op.type == EXPONENT_ASSIGN:
+            new_val = current_val ** expr_val
+        else:
+            raise Exception(f"Runtime error: Unknown augmented assignment operator {node.op.value}")
+        
+        self.assign_variable(var_name, new_val)  # Use assign_variable
+    
+    def visit_InputStatement(self, node):
+        """
+        Handle input for any supported type. Values are whitespace separated
+        similar to C++'s cin operator.
+        """
+        try:
+            input_line = input()
+            if node.type_token.value == 'list' and len(node.variables) == 1:
+                parts = [input_line.strip()]
+            else:
+                parts = input_line.strip().split()
+        except EOFError:
+            raise Exception("Runtime error: Unexpected end of input during input statement.")
+
+        if len(parts) != len(node.variables):
+            raise Exception(
+                f"Runtime error: Expected {len(node.variables)} inputs, but received {len(parts)}.")
+
+        def convert(val: str):
+            t = node.type_token.value
+            if t == 'int':
+                return int(val)
+            if t == 'string':
+                return val
+            if t == 'bool':
+                if val.lower() in ('true', '1', 't'):
+                    return True
+                if val.lower() in ('false', '0', 'f'):
+                    return False
+                raise ValueError
+            if t == 'list':
+                import ast
+                return ast.literal_eval(val)
+            return val
+
+        try:
+            input_values = [convert(p) for p in parts]
+        except (ValueError, SyntaxError):
+            raise Exception(f"Runtime error: Invalid input for type {node.type_token.value}.")
+
+        for i, var_node in enumerate(node.variables):
+            self.assign_variable(var_node.value, input_values[i])
+
+    def visit_TypeCast(self, node):
+        value = self.visit(node.expr)
+        t = node.type_token.value
+        try:
+            if t == 'int':
+                return int(value)
+            if t == 'string':
+                return str(value)
+            if t == 'bool':
+                return bool(value)
+            if t == 'list':
+                return list(value)
+        except Exception:
+            raise Exception(f"Runtime error: Cannot convert to {t}.")
+        raise Exception(f"Runtime error: Unknown type {t} in cast")
+    
+    def visit_OutputStatement(self, node):
+        """
+        Handle output: evaluate all expressions and print their values to stdout
+        without newlines, supporting chaining.
+        """
+        for expr in node.expressions:
+            value = self.visit(expr)
+            sys.stdout.write(str(value))
+    
+    def visit_ForStatement(self, node):
+        """
+        Handle for loop execution.
+        Loops from start_expr to end_expr (inclusive), assigning the current
+        iteration value to the loop variable and executing the body statements.
+        """
+        loop_var_name = node.variable.value
+        start_val = self.visit(node.start_expr)
+        end_val = self.visit(node.end_expr)
+        step_val = self.visit(node.step_expr) if node.step_expr is not None else (1 if start_val <= end_val else -1)
+        
+        if not isinstance(start_val, int) or not isinstance(end_val, int) or not isinstance(step_val, int):
+            raise Exception("Runtime error: For loop range must be integers.")
+        
+        # Enter a new scope for the loop body
+        self.enter_scope()
+        
+        try:
+            stop = end_val + (1 if step_val > 0 else -1)
+            for i in range(start_val, stop, step_val):
+                self.current_scope[loop_var_name] = i  # Loop var specific to this scope
+                for statement in node.body:
+                    self.visit(statement)
+        finally:
+            self.exit_scope()  # Ensure scope is exited even if error occurs
+    
+    def visit_WhileStatement(self, node):
+        """
+        Handle while loop execution.
+        The loop continues as long as the condition evaluates to true.
+        The loop variable (from `loop_var`) is assumed to be defined in an outer scope
+        and modified within the body.
+        """
+        # No new scope is entered for the while loop itself; its condition and body run
+        # in the same scope as where the while loop statement itself is defined.
+        # The variable used in the loop (e.g., 'x' in 'x while x < 5') is not local to the loop.
+        
+        while True:
+            condition_result = self.visit(node.condition)
+            
+            if not isinstance(condition_result, bool):
+                raise Exception("Runtime error: While loop condition must evaluate to a boolean.")
+            
+            if not condition_result:
+                break  # Exit loop if condition is false
+            
+            # Execute loop body
+            for statement in node.body:
+                self.visit(statement)
+    
+    def visit_IfExpression(self, node):
+        condition_val = self.visit(node.condition)
+        if condition_val:
+            return self.visit(node.then_branch)
+        elif node.else_branch is not None:
+            return self.visit(node.else_branch)
+        else:
+            return None
+    
+    def visit_ExpressionStatement(self, node):  # New: Visit method for ExpressionStatement
+        """Evaluates the expression within an ExpressionStatement."""
+        return self.visit(node.expression)
+    
+    def interpret(self):
+        """Start the interpretation process by parsing the program and visiting its AST."""
+        if self.parser:
+            tree = self.parser.program()
+            self.visit(tree)  # Start traversing the AST from the root (Program node)
+        else:
+            raise Exception("Interpreter error: No parser set.")

--- a/plank/lexer.py
+++ b/plank/lexer.py
@@ -34,6 +34,13 @@ class Lexer:
                 'if': (KEYWORD_IF, 'if'),
                 'else': (KEYWORD_ELSE, 'else'),
                 'c': (KEYWORD_C, 'c'),
+                'len': (KEYWORD_LEN, 'len'),
+                'head': (KEYWORD_HEAD, 'head'),
+                'tail': (KEYWORD_TAIL, 'tail'),
+                'abs': (KEYWORD_ABS, 'abs'),
+                'min': (KEYWORD_MIN, 'min'),
+                'max': (KEYWORD_MAX, 'max'),
+                'clamp': (KEYWORD_CLAMP, 'clamp'),
         }
 
         MULTI_OPS = {

--- a/plank/parser.py
+++ b/plank/parser.py
@@ -6,567 +6,591 @@ from plank.token_types import *
 # --- Parser ---
 # Builds the Abstract Syntax Tree from the token stream, respecting operator precedence.
 class Parser:
-	def __init__(self, lexer):
-		self.lexer = lexer
-		self.current_token = self.lexer.get_next_token()  # The current token being processed
-	
-	def error(self, message="Invalid syntax"):
-		"""Report a parsing error."""
-		raise Exception(f'Parser error: {message} at token {self.current_token}')
-	
-	def eat(self, token_type):
-		"""
-		Consume the current token if its type matches the expected type,
-		then advance to the next token. Otherwise, raise an error.
-		"""
-		if self.current_token.type == token_type:
-			self.current_token = self.lexer.get_next_token()
-		else:
-			self.error(f"Expected token type {token_type}, but got {self.current_token.type}")
-	
-	def program(self):
-		"""
-		Parses the entire program.
-		program ::= (statement (SEMICOLON statement)*)* EOF
-		"""
-		statements = []
-		while self.current_token.type != EOF:
-			statements.append(self.statement())
-			# Allow multiple statements on one line separated by semicolons
-			while self.current_token.type == SEMICOLON:
-				self.eat(SEMICOLON)
-				if self.current_token.type != EOF and self.current_token.type != RBRACE:  # Don't parse empty statement at end of block
-					statements.append(self.statement())
-		return Program(statements)
-	
-	def statement(self):
-		"""
-		Parses a single statement.
-		statement ::= output_statement | for_statement | while_statement |
-					  input_statement | list_assignment_statement |
-					  assignment_statement | augmented_assignment_statement |
-					  expression_statement
-		"""
-		# Try parsing specific statement types first
-		if self.current_token.type == KEYWORD_OUT:
-			return self.output_statement()
-		elif self.current_token.type == LPAREN:
-			# Look ahead for 'for' or 'while' to distinguish loops from expressions
-			lexer_pos_backup = self.lexer.pos
-			lexer_current_char_backup = self.lexer.current_char
-			parser_current_token_backup = self.current_token
-			try:
-				self.eat(LPAREN)
-				# Check for IDENTIFIER followed by KEYWORD_FOR or KEYWORD_WHILE
-				if self.current_token.type == IDENTIFIER:
-					self.eat(IDENTIFIER)  # Consume loop var
-					if self.current_token.type == KEYWORD_FOR:
-						# It's a for loop, reset and parse
-						self.lexer.pos = lexer_pos_backup
-						self.lexer.current_char = lexer_current_char_backup
-						self.current_token = parser_current_token_backup
-						return self.for_statement()
-					elif self.current_token.type == KEYWORD_WHILE:
-						# It's a while loop, reset and parse
-						self.lexer.pos = lexer_pos_backup
-						self.lexer.current_char = lexer_current_char_backup
-						self.current_token = parser_current_token_backup
-						return self.while_statement()
-				# If we get here, it was LPAREN but not a loop structure, so it's an expression.
-				# Reset and let the general expression parsing handle it.
-				self.lexer.pos = lexer_pos_backup
-				self.lexer.current_char = lexer_current_char_backup
-				self.current_token = parser_current_token_backup
-				return self.expression_statement()  # Fallback to expression statement
-			except Exception:
-				# If an error occurred during lookahead, it's not a loop.
-				# Now try to parse it as a general expression statement.
-				self.lexer.pos = lexer_pos_backup
-				self.lexer.current_char = lexer_current_char_backup
-				self.current_token = parser_current_token_backup
-				return self.expression_statement()  # This might still fail if it's truly malformed.
-		
-		# For IDENTIFIER, try specific assignment/input forms first, then general expression
-		elif self.current_token.type == IDENTIFIER:
-			# Try list assignment: IDENTIFIER LBRACKET ... <- ...
-			lexer_pos_backup = self.lexer.pos
-			lexer_current_char_backup = self.lexer.current_char
-			parser_current_token_backup = self.current_token
-			try:
-				temp_var = self.variable()  # Consumes IDENTIFIER
-				if self.current_token.type == LBRACKET:
-					self.eat(LBRACKET)
-					self.expression()  # Consume index expression
-					self.eat(RBRACKET)
-					if self.current_token.type == ASSIGN:
-						self.lexer.pos = lexer_pos_backup
-						self.lexer.current_char = lexer_current_char_backup
-						self.current_token = parser_current_token_backup
-						return self.list_assignment_statement()
-				raise Exception("Not a list assignment pattern")  # Force backtrack if not list assign
-			except Exception:
-				self.lexer.pos = lexer_pos_backup
-				self.lexer.current_char = lexer_current_char_backup
-				self.current_token = parser_current_token_backup
-			
-			# Try input statement: IDENTIFIER (COMMA IDENTIFIER)* ASSIGN KEYWORD_INT
-			lexer_pos_backup = self.lexer.pos
-			lexer_current_char_backup = self.lexer.current_char
-			parser_current_token_backup = self.current_token
-			try:
-				self.variable()	 # Consume first IDENTIFIER
-				while self.current_token.type == COMMA:
-					self.eat(COMMA)
-					self.variable()
-				if self.current_token.type == ASSIGN:
-					self.eat(ASSIGN)
-					if self.current_token.type in (KEYWORD_INT, KEYWORD_STRING, KEYWORD_BOOL, KEYWORD_LIST):
-						self.lexer.pos = lexer_pos_backup
-						self.lexer.current_char = lexer_current_char_backup
-						self.current_token = parser_current_token_backup
-						return self.input_statement()
-				raise Exception("Not an input statement pattern")  # Force backtrack
-			except Exception:
-				self.lexer.pos = lexer_pos_backup
-				self.lexer.current_char = lexer_current_char_backup
-				self.current_token = parser_current_token_backup
-			
-			# Try regular or augmented assignment: IDENTIFIER ASSIGN expression / IDENTIFIER OP_ASSIGN expression
-			lexer_pos_backup = self.lexer.pos
-			lexer_current_char_backup = self.lexer.current_char
-			parser_current_token_backup = self.current_token
-			try:
-				self.variable()	 # Consume IDENTIFIER
-				if self.current_token.type == ASSIGN:
-					self.lexer.pos = lexer_pos_backup
-					self.lexer.current_char = lexer_current_char_backup
-					self.current_token = parser_current_token_backup
-					return self.assignment_statement()
-				elif self.current_token.type in (
-						PLUS_ASSIGN, MINUS_ASSIGN, MULTIPLY_ASSIGN, DIVIDE_ASSIGN, EXPONENT_ASSIGN,
-						FLOOR_DIVIDE_ASSIGN):
-					self.lexer.pos = lexer_pos_backup
-					self.lexer.current_char = lexer_current_char_backup
-					self.current_token = parser_current_token_backup
-					return self.augmented_assignment_statement()
-				raise Exception("Not an assignment pattern")  # Force backtrack
-			except Exception:
-				self.lexer.pos = lexer_pos_backup
-				self.lexer.current_char = lexer_current_char_backup
-				self.current_token = parser_current_token_backup
-			
-			# If none of the specific identifier-starting statements matched, it must be an expression statement.
-			return self.expression_statement()
-		
-		# If it's none of the above, it must be an expression statement (e.g., a literal, a function call)
-		else:
-			return self.expression_statement()
-	
-	def input_statement(self):
-		"""
-		Parses an input statement.
-		input_statement ::= IDENTIFIER (COMMA IDENTIFIER)* ASSIGN TYPE
-		where TYPE is one of int, string, bool, list
-		"""
-		variables = [self.variable()]
-		while self.current_token.type == COMMA:
-			self.eat(COMMA)
-			variables.append(self.variable())
-		
-		self.eat(ASSIGN)
-		if self.current_token.type not in (KEYWORD_INT, KEYWORD_STRING, KEYWORD_BOOL, KEYWORD_LIST):
-			self.error("Expected type after '<-'")
-		type_token = self.current_token
-		self.eat(type_token.type)
-		return InputStatement(variables, Token(type_token.type, type_token.value))
-	
-	def output_statement(self):
-		"""
-		Parses an output statement, now supporting chaining.
-		output_statement ::= KEYWORD_OUT ASSIGN expression (ASSIGN expression)*
-		"""
-		self.eat(KEYWORD_OUT)
-		expressions = []
-		# The first 'ASSIGN' is mandatory after 'out'
-		self.eat(ASSIGN)
-		expressions.append(self.expression())
-		
-		# Subsequent 'ASSIGN' tokens allow chaining
-		while self.current_token.type == ASSIGN:
-			self.eat(ASSIGN)
-			expressions.append(self.expression())
-		
-		return OutputStatement(expressions)
-	
-	def assignment_statement(self):
-		"""
-		Parses an assignment statement.
-		assignment_statement ::= IDENTIFIER ASSIGN expression
-		"""
-		var_node = self.variable()
-		self.eat(ASSIGN)
-		expr_node = self.expression()
-		return Assign(var_node, Token(ASSIGN, '<-'), expr_node)
-	
-	def list_assignment_statement(self):
-		"""
-		Parses a list element assignment statement.
-		list_assignment_statement ::= IDENTIFIER LBRACKET expression RBRACKET ASSIGN expression
-		"""
-		list_var_node = self.variable()
-		self.eat(LBRACKET)
-		index_expr = self.expression()
-		self.eat(RBRACKET)
-		self.eat(ASSIGN)
-		value_expr = self.expression()
-		return ListAssign(list_var_node, index_expr, value_expr)
-	
-	def augmented_assignment_statement(self):
-		"""
-		Parses an augmented assignment statement.
-		augmented_assignment_statement ::= IDENTIFIER (PLUS_ASSIGN | MINUS_ASSIGN | ...) expression
-		"""
-		var_node = self.variable()
-		op_token = self.current_token
-		self.eat(op_token.type)	 # Consume the augmented assignment operator
-		expr_node = self.expression()
-		return AugmentedAssign(var_node, op_token, expr_node)
-	
-	def for_statement(self):
-		"""
-		Parses a for loop statement.
-		for_statement ::= LPAREN IDENTIFIER KEYWORD_FOR expression RANGE_OP expression (RANGE_OP expression)? RPAREN ARROW LBRACE (statement (SEMICOLON statement)*)* RBRACE
-		"""
-		self.eat(LPAREN)  # Consume '('
-		loop_var = self.variable()  # Get the loop variable (e.g., 'x')
-		self.eat(KEYWORD_FOR)  # Consume 'for'
-		start_expr = self.expression()	# Get the start expression (e.g., '1')
-		self.eat(RANGE_OP)  # Consume '..'
-		end_expr = self.expression()  # Get the end expression (e.g., '5')
-		step_expr = None
-		if self.current_token.type == RANGE_OP:
-			self.eat(RANGE_OP)
-			step_expr = self.expression()
-		self.eat(RPAREN)  # Consume ')'
-		self.eat(ARROW)	 # Consume '->'
-		self.eat(LBRACE)  # Consume '{'
-		
-		body_statements = []
-		while self.current_token.type != RBRACE:
-			body_statements.append(self.statement())
-			# Allow multiple statements on one line within the block, separated by semicolons
-			while self.current_token.type == SEMICOLON:
-				self.eat(SEMICOLON)
-				# Only parse another statement if it's not the end of the block or EOF
-				if self.current_token.type != RBRACE and self.current_token.type != EOF:
-					body_statements.append(self.statement())
-		self.eat(RBRACE)  # Consume '}'
-		return ForStatement(loop_var, start_expr, end_expr, body_statements, step_expr)
-	
-	def while_statement(self):
-		"""
-		Parses a while loop statement.
-		while_statement ::= LPAREN IDENTIFIER KEYWORD_WHILE expression RPAREN ARROW LBRACE (statement (SEMICOLON statement)*)* RBRACE
-		"""
-		self.eat(LPAREN)  # Consume '('
-		loop_var = self.variable()  # Consume the loop variable (e.g., 'x')
-		self.eat(KEYWORD_WHILE)	 # Consume 'while'
-		condition = self.expression()  # Get the condition expression (e.g., 'x < 5')
-		self.eat(RPAREN)  # Consume ')'
-		self.eat(ARROW)	 # Consume '->'
-		self.eat(LBRACE)  # Consume '{'
-		
-		body_statements = []
-		while self.current_token.type != RBRACE:
-			body_statements.append(self.statement())
-			while self.current_token.type == SEMICOLON:
-				self.eat(SEMICOLON)
-				if self.current_token.type != RBRACE and self.current_token.type != EOF:
-					body_statements.append(self.statement())
-		self.eat(RBRACE)  # Consume '}'
-		return WhileStatement(loop_var, condition, body_statements)
-	
-	def expression_statement(self):	 # New: Parses an expression as a statement
-		"""Parses an expression as a statement."""
-		node = self.expression()
-		return ExpressionStatement(node)
-	
-	# Expression parsing methods, ordered by precedence (lowest to highest)
-	def expression(self):
-		"""Handles 'or' operator."""
-		node = self.logical_and_expression()
-		while self.current_token.type == KEYWORD_OR:
-			token = self.current_token
-			self.eat(KEYWORD_OR)
-			node = BinOp(left=node, op=token, right=self.logical_and_expression())
-		return node
-	
-	def logical_and_expression(self):
-		"""Handles 'and' operator."""
-		node = self.comparison_expression()
-		while self.current_token.type == KEYWORD_AND:
-			token = self.current_token
-			self.eat(KEYWORD_AND)
-			node = BinOp(left=node, op=token, right=self.comparison_expression())
-		return node
-	
-	def comparison_expression(self):
-		"""Handles comparison operators (==, !=, <, >, <=, >=)."""
-		node = self.additive_expression()
-		while self.current_token.type in (EQ, NEQ, LT, GT, LTE, GTE):
-			token = self.current_token
-			self.eat(token.type)
-			node = BinOp(left=node, op=token, right=self.additive_expression())
-		return node
-	
-	def additive_expression(self):
-		"""Handles '+' and '-' operators."""
-		node = self.multiplicative_expression()
-		while self.current_token.type in (PLUS, MINUS):
-			token = self.current_token
-			if token.type == PLUS:
-				self.eat(PLUS)
-			elif token.type == MINUS:
-				self.eat(MINUS)
-			node = BinOp(left=node, op=token, right=self.multiplicative_expression())
-		return node
-	
-	def multiplicative_expression(self):
-		"""Handles '*', '/', '//' operators."""
-		node = self.exponentiation_expression()
-		while self.current_token.type in (MULTIPLY, DIVIDE, FLOOR_DIVIDE):
-			token = self.current_token
-			if token.type == MULTIPLY:
-				self.eat(MULTIPLY)
-			elif token.type == DIVIDE:
-				self.eat(DIVIDE)
-			elif token.type == FLOOR_DIVIDE:
-				self.eat(FLOOR_DIVIDE)
-			node = BinOp(left=node, op=token, right=self.exponentiation_expression())
-		return node
-	
-	def exponentiation_expression(self):
-		"""Handles '**' operator (right-associative)."""
-		node = self.unary_expression()
-		if self.current_token.type == EXPONENT:
-			token = self.current_token
-			self.eat(EXPONENT)
-			node = BinOp(left=node, op=token, right=self.exponentiation_expression())
-		return node
-	
-	def unary_expression(self):
-		"""Handles unary 'not' (and potential unary minus)."""
-		if self.current_token.type == KEYWORD_NOT:
-			token = self.current_token
-			self.eat(KEYWORD_NOT)
-			return UnaryOp(op=token, right=self.cast_expression())
-		elif self.current_token.type == MINUS:
-			token = self.current_token
-			self.eat(MINUS)
-			return UnaryOp(op=token, right=self.cast_expression())
-		return self.cast_expression()
+    def __init__(self, lexer):
+        self.lexer = lexer
+        self.current_token = self.lexer.get_next_token()  # The current token being processed
+    
+    def error(self, message="Invalid syntax"):
+        """Report a parsing error."""
+        raise Exception(f'Parser error: {message} at token {self.current_token}')
+    
+    def eat(self, token_type):
+        """
+        Consume the current token if its type matches the expected type,
+        then advance to the next token. Otherwise, raise an error.
+        """
+        if self.current_token.type == token_type:
+            self.current_token = self.lexer.get_next_token()
+        else:
+            self.error(f"Expected token type {token_type}, but got {self.current_token.type}")
+    
+    def program(self):
+        """
+        Parses the entire program.
+        program ::= (statement (SEMICOLON statement)*)* EOF
+        """
+        statements = []
+        while self.current_token.type != EOF:
+            statements.append(self.statement())
+            # Allow multiple statements on one line separated by semicolons
+            while self.current_token.type == SEMICOLON:
+                self.eat(SEMICOLON)
+                if self.current_token.type != EOF and self.current_token.type != RBRACE:  # Don't parse empty statement at end of block
+                    statements.append(self.statement())
+        return Program(statements)
+    
+    def statement(self):
+        """
+        Parses a single statement.
+        statement ::= output_statement | for_statement | while_statement |
+                      input_statement | list_assignment_statement |
+                      assignment_statement | augmented_assignment_statement |
+                      expression_statement
+        """
+        # Try parsing specific statement types first
+        if self.current_token.type == KEYWORD_OUT:
+            return self.output_statement()
+        elif self.current_token.type == LPAREN:
+            # Look ahead for 'for' or 'while' to distinguish loops from expressions
+            lexer_pos_backup = self.lexer.pos
+            lexer_current_char_backup = self.lexer.current_char
+            parser_current_token_backup = self.current_token
+            try:
+                self.eat(LPAREN)
+                # Check for IDENTIFIER followed by KEYWORD_FOR or KEYWORD_WHILE
+                if self.current_token.type == IDENTIFIER:
+                    self.eat(IDENTIFIER)  # Consume loop var
+                    if self.current_token.type == KEYWORD_FOR:
+                        # It's a for loop, reset and parse
+                        self.lexer.pos = lexer_pos_backup
+                        self.lexer.current_char = lexer_current_char_backup
+                        self.current_token = parser_current_token_backup
+                        return self.for_statement()
+                    elif self.current_token.type == KEYWORD_WHILE:
+                        # It's a while loop, reset and parse
+                        self.lexer.pos = lexer_pos_backup
+                        self.lexer.current_char = lexer_current_char_backup
+                        self.current_token = parser_current_token_backup
+                        return self.while_statement()
+                # If we get here, it was LPAREN but not a loop structure, so it's an expression.
+                # Reset and let the general expression parsing handle it.
+                self.lexer.pos = lexer_pos_backup
+                self.lexer.current_char = lexer_current_char_backup
+                self.current_token = parser_current_token_backup
+                return self.expression_statement()  # Fallback to expression statement
+            except Exception:
+                # If an error occurred during lookahead, it's not a loop.
+                # Now try to parse it as a general expression statement.
+                self.lexer.pos = lexer_pos_backup
+                self.lexer.current_char = lexer_current_char_backup
+                self.current_token = parser_current_token_backup
+                return self.expression_statement()  # This might still fail if it's truly malformed.
+        
+        # For IDENTIFIER, try specific assignment/input forms first, then general expression
+        elif self.current_token.type == IDENTIFIER:
+            # Try list assignment: IDENTIFIER LBRACKET ... <- ...
+            lexer_pos_backup = self.lexer.pos
+            lexer_current_char_backup = self.lexer.current_char
+            parser_current_token_backup = self.current_token
+            try:
+                temp_var = self.variable()  # Consumes IDENTIFIER
+                if self.current_token.type == LBRACKET:
+                    self.eat(LBRACKET)
+                    self.expression()  # Consume index expression
+                    self.eat(RBRACKET)
+                    if self.current_token.type == ASSIGN:
+                        self.lexer.pos = lexer_pos_backup
+                        self.lexer.current_char = lexer_current_char_backup
+                        self.current_token = parser_current_token_backup
+                        return self.list_assignment_statement()
+                raise Exception("Not a list assignment pattern")  # Force backtrack if not list assign
+            except Exception:
+                self.lexer.pos = lexer_pos_backup
+                self.lexer.current_char = lexer_current_char_backup
+                self.current_token = parser_current_token_backup
+            
+            # Try input statement: IDENTIFIER (COMMA IDENTIFIER)* ASSIGN KEYWORD_INT
+            lexer_pos_backup = self.lexer.pos
+            lexer_current_char_backup = self.lexer.current_char
+            parser_current_token_backup = self.current_token
+            try:
+                self.variable()  # Consume first IDENTIFIER
+                while self.current_token.type == COMMA:
+                    self.eat(COMMA)
+                    self.variable()
+                if self.current_token.type == ASSIGN:
+                    self.eat(ASSIGN)
+                    if self.current_token.type in (KEYWORD_INT, KEYWORD_STRING, KEYWORD_BOOL, KEYWORD_LIST):
+                        self.lexer.pos = lexer_pos_backup
+                        self.lexer.current_char = lexer_current_char_backup
+                        self.current_token = parser_current_token_backup
+                        return self.input_statement()
+                raise Exception("Not an input statement pattern")  # Force backtrack
+            except Exception:
+                self.lexer.pos = lexer_pos_backup
+                self.lexer.current_char = lexer_current_char_backup
+                self.current_token = parser_current_token_backup
+            
+            # Try regular or augmented assignment: IDENTIFIER ASSIGN expression / IDENTIFIER OP_ASSIGN expression
+            lexer_pos_backup = self.lexer.pos
+            lexer_current_char_backup = self.lexer.current_char
+            parser_current_token_backup = self.current_token
+            try:
+                self.variable()  # Consume IDENTIFIER
+                if self.current_token.type == ASSIGN:
+                    self.lexer.pos = lexer_pos_backup
+                    self.lexer.current_char = lexer_current_char_backup
+                    self.current_token = parser_current_token_backup
+                    return self.assignment_statement()
+                elif self.current_token.type in (
+                        PLUS_ASSIGN, MINUS_ASSIGN, MULTIPLY_ASSIGN, DIVIDE_ASSIGN, EXPONENT_ASSIGN,
+                        FLOOR_DIVIDE_ASSIGN):
+                    self.lexer.pos = lexer_pos_backup
+                    self.lexer.current_char = lexer_current_char_backup
+                    self.current_token = parser_current_token_backup
+                    return self.augmented_assignment_statement()
+                raise Exception("Not an assignment pattern")  # Force backtrack
+            except Exception:
+                self.lexer.pos = lexer_pos_backup
+                self.lexer.current_char = lexer_current_char_backup
+                self.current_token = parser_current_token_backup
+            
+            # If none of the specific identifier-starting statements matched, it must be an expression statement.
+            return self.expression_statement()
+        
+        # If it's none of the above, it must be an expression statement (e.g., a literal, a function call)
+        else:
+            return self.expression_statement()
+    
+    def input_statement(self):
+        """
+        Parses an input statement.
+        input_statement ::= IDENTIFIER (COMMA IDENTIFIER)* ASSIGN TYPE
+        where TYPE is one of int, string, bool, list
+        """
+        variables = [self.variable()]
+        while self.current_token.type == COMMA:
+            self.eat(COMMA)
+            variables.append(self.variable())
+        
+        self.eat(ASSIGN)
+        if self.current_token.type not in (KEYWORD_INT, KEYWORD_STRING, KEYWORD_BOOL, KEYWORD_LIST):
+            self.error("Expected type after '<-'")
+        type_token = self.current_token
+        self.eat(type_token.type)
+        return InputStatement(variables, Token(type_token.type, type_token.value))
+    
+    def output_statement(self):
+        """
+        Parses an output statement, now supporting chaining.
+        output_statement ::= KEYWORD_OUT ASSIGN expression (ASSIGN expression)*
+        """
+        self.eat(KEYWORD_OUT)
+        expressions = []
+        # The first 'ASSIGN' is mandatory after 'out'
+        self.eat(ASSIGN)
+        expressions.append(self.expression())
+        
+        # Subsequent 'ASSIGN' tokens allow chaining
+        while self.current_token.type == ASSIGN:
+            self.eat(ASSIGN)
+            expressions.append(self.expression())
+        
+        return OutputStatement(expressions)
+    
+    def assignment_statement(self):
+        """
+        Parses an assignment statement.
+        assignment_statement ::= IDENTIFIER ASSIGN expression
+        """
+        var_node = self.variable()
+        self.eat(ASSIGN)
+        expr_node = self.expression()
+        return Assign(var_node, Token(ASSIGN, '<-'), expr_node)
+    
+    def list_assignment_statement(self):
+        """
+        Parses a list element assignment statement.
+        list_assignment_statement ::= IDENTIFIER LBRACKET expression RBRACKET ASSIGN expression
+        """
+        list_var_node = self.variable()
+        self.eat(LBRACKET)
+        index_expr = self.expression()
+        self.eat(RBRACKET)
+        self.eat(ASSIGN)
+        value_expr = self.expression()
+        return ListAssign(list_var_node, index_expr, value_expr)
+    
+    def augmented_assignment_statement(self):
+        """
+        Parses an augmented assignment statement.
+        augmented_assignment_statement ::= IDENTIFIER (PLUS_ASSIGN | MINUS_ASSIGN | ...) expression
+        """
+        var_node = self.variable()
+        op_token = self.current_token
+        self.eat(op_token.type)  # Consume the augmented assignment operator
+        expr_node = self.expression()
+        return AugmentedAssign(var_node, op_token, expr_node)
+    
+    def for_statement(self):
+        """
+        Parses a for loop statement.
+        for_statement ::= LPAREN IDENTIFIER KEYWORD_FOR expression RANGE_OP expression (RANGE_OP expression)? RPAREN ARROW LBRACE (statement (SEMICOLON statement)*)* RBRACE
+        """
+        self.eat(LPAREN)  # Consume '('
+        loop_var = self.variable()  # Get the loop variable (e.g., 'x')
+        self.eat(KEYWORD_FOR)  # Consume 'for'
+        start_expr = self.expression()  # Get the start expression (e.g., '1')
+        self.eat(RANGE_OP)  # Consume '..'
+        end_expr = self.expression()  # Get the end expression (e.g., '5')
+        step_expr = None
+        if self.current_token.type == RANGE_OP:
+            self.eat(RANGE_OP)
+            step_expr = self.expression()
+        self.eat(RPAREN)  # Consume ')'
+        self.eat(ARROW)  # Consume '->'
+        self.eat(LBRACE)  # Consume '{'
+        
+        body_statements = []
+        while self.current_token.type != RBRACE:
+            body_statements.append(self.statement())
+            # Allow multiple statements on one line within the block, separated by semicolons
+            while self.current_token.type == SEMICOLON:
+                self.eat(SEMICOLON)
+                # Only parse another statement if it's not the end of the block or EOF
+                if self.current_token.type != RBRACE and self.current_token.type != EOF:
+                    body_statements.append(self.statement())
+        self.eat(RBRACE)  # Consume '}'
+        return ForStatement(loop_var, start_expr, end_expr, body_statements, step_expr)
+    
+    def while_statement(self):
+        """
+        Parses a while loop statement.
+        while_statement ::= LPAREN IDENTIFIER KEYWORD_WHILE expression RPAREN ARROW LBRACE (statement (SEMICOLON statement)*)* RBRACE
+        """
+        self.eat(LPAREN)  # Consume '('
+        loop_var = self.variable()  # Consume the loop variable (e.g., 'x')
+        self.eat(KEYWORD_WHILE)  # Consume 'while'
+        condition = self.expression()  # Get the condition expression (e.g., 'x < 5')
+        self.eat(RPAREN)  # Consume ')'
+        self.eat(ARROW)  # Consume '->'
+        self.eat(LBRACE)  # Consume '{'
+        
+        body_statements = []
+        while self.current_token.type != RBRACE:
+            body_statements.append(self.statement())
+            while self.current_token.type == SEMICOLON:
+                self.eat(SEMICOLON)
+                if self.current_token.type != RBRACE and self.current_token.type != EOF:
+                    body_statements.append(self.statement())
+        self.eat(RBRACE)  # Consume '}'
+        return WhileStatement(loop_var, condition, body_statements)
+    
+    def expression_statement(self):  # New: Parses an expression as a statement
+        """Parses an expression as a statement."""
+        node = self.expression()
+        return ExpressionStatement(node)
+    
+    # Expression parsing methods, ordered by precedence (lowest to highest)
+    def expression(self):
+        """Handles 'or' operator."""
+        node = self.logical_and_expression()
+        while self.current_token.type == KEYWORD_OR:
+            token = self.current_token
+            self.eat(KEYWORD_OR)
+            node = BinOp(left=node, op=token, right=self.logical_and_expression())
+        return node
+    
+    def logical_and_expression(self):
+        """Handles 'and' operator."""
+        node = self.comparison_expression()
+        while self.current_token.type == KEYWORD_AND:
+            token = self.current_token
+            self.eat(KEYWORD_AND)
+            node = BinOp(left=node, op=token, right=self.comparison_expression())
+        return node
+    
+    def comparison_expression(self):
+        """Handles comparison operators (==, !=, <, >, <=, >=)."""
+        node = self.additive_expression()
+        while self.current_token.type in (EQ, NEQ, LT, GT, LTE, GTE):
+            token = self.current_token
+            self.eat(token.type)
+            node = BinOp(left=node, op=token, right=self.additive_expression())
+        return node
+    
+    def additive_expression(self):
+        """Handles '+' and '-' operators."""
+        node = self.multiplicative_expression()
+        while self.current_token.type in (PLUS, MINUS):
+            token = self.current_token
+            if token.type == PLUS:
+                self.eat(PLUS)
+            elif token.type == MINUS:
+                self.eat(MINUS)
+            node = BinOp(left=node, op=token, right=self.multiplicative_expression())
+        return node
+    
+    def multiplicative_expression(self):
+        """Handles '*', '/', '//' operators."""
+        node = self.exponentiation_expression()
+        while self.current_token.type in (MULTIPLY, DIVIDE, FLOOR_DIVIDE):
+            token = self.current_token
+            if token.type == MULTIPLY:
+                self.eat(MULTIPLY)
+            elif token.type == DIVIDE:
+                self.eat(DIVIDE)
+            elif token.type == FLOOR_DIVIDE:
+                self.eat(FLOOR_DIVIDE)
+            node = BinOp(left=node, op=token, right=self.exponentiation_expression())
+        return node
+    
+    def exponentiation_expression(self):
+        """Handles '**' operator (right-associative)."""
+        node = self.unary_expression()
+        if self.current_token.type == EXPONENT:
+            token = self.current_token
+            self.eat(EXPONENT)
+            node = BinOp(left=node, op=token, right=self.exponentiation_expression())
+        return node
+    
+    def unary_expression(self):
+        """Handles unary 'not' (and potential unary minus)."""
+        if self.current_token.type == KEYWORD_NOT:
+            token = self.current_token
+            self.eat(KEYWORD_NOT)
+            return UnaryOp(op=token, right=self.cast_expression())
+        elif self.current_token.type == MINUS:
+            token = self.current_token
+            self.eat(MINUS)
+            return UnaryOp(op=token, right=self.cast_expression())
+        return self.cast_expression()
 
-	def cast_expression(self):
-		node = self.call_or_index_expression()
-		while self.current_token.type == ARROW:
-			# Peek ahead to ensure this is a type cast and not part of another construct
-			saved_pos = self.lexer.pos
-			saved_char = self.lexer.current_char
-			saved_token = self.current_token
-			next_token = self.lexer.get_next_token()
-			self.lexer.pos = saved_pos
-			self.lexer.current_char = saved_char
-			self.current_token = saved_token
+    def cast_expression(self):
+        node = self.call_or_index_expression()
+        while self.current_token.type == ARROW:
+            # Peek ahead to ensure this is a type cast and not part of another construct
+            saved_pos = self.lexer.pos
+            saved_char = self.lexer.current_char
+            saved_token = self.current_token
+            next_token = self.lexer.get_next_token()
+            self.lexer.pos = saved_pos
+            self.lexer.current_char = saved_char
+            self.current_token = saved_token
 
-			if next_token.type not in (KEYWORD_INT, KEYWORD_STRING, KEYWORD_BOOL, KEYWORD_LIST):
-				break
+            if next_token.type not in (KEYWORD_INT, KEYWORD_STRING, KEYWORD_BOOL, KEYWORD_LIST):
+                break
 
-			self.eat(ARROW)
-			type_token = self.current_token
-			self.eat(type_token.type)
-			node = TypeCast(node, type_token)
-		return node
-	
-	def call_or_index_expression(self):  # Handles both indexing and function calls as postfix
-		"""
-		Parses a primary expression, potentially followed by zero or more index accesses or function calls.
-		call_or_index_expression ::= primary (LBRACKET expression RBRACKET | LPAREN (expression (COMMA expression)*)? RPAREN)*
-		"""
-		node = self.primary()  # Start with a primary (variable, literal, lambda, etc.)
-		while self.current_token.type in (LBRACKET, LPAREN):
-			if self.current_token.type == LBRACKET:	 # It's an index access
-				self.eat(LBRACKET)
-				index_expr = self.expression()
-				self.eat(RBRACKET)
-				node = IndexAccess(node, index_expr)
-			elif self.current_token.type == LPAREN:	 # It's a function call
-				self.eat(LPAREN)
-				args = []
-				if self.current_token.type != RPAREN:  # Check if there are arguments
-					args.append(self.expression())
-					while self.current_token.type == COMMA:
-						self.eat(COMMA)
-						args.append(self.expression())
-				self.eat(RPAREN)
-				node = Call(node, args)	 # The node here is the function being called (e.g., Var('square'))
-		return node
-	
-	def primary(self):
-		"""
-		Parses the highest precedence elements: numbers, variables, strings, booleans, list literals, lambda expressions, or parenthesized expressions.
-		primary ::= INTEGER | IDENTIFIER | STRING | BOOLEAN | ListLiteral | Lambda | LPAREN expression RPAREN
-		"""
-		token = self.current_token
-		if token.type == KEYWORD_IF:
-			return self.if_expression()
-		if token.type == INTEGER:
-			self.eat(INTEGER)
-			return Num(token)
-		elif token.type == IDENTIFIER:
-			self.eat(IDENTIFIER)
-			return Var(token)
-		elif token.type == STRING:
-			self.eat(STRING)
-			return String(token)
-		elif token.type == KEYWORD_TRUE or token.type == KEYWORD_FALSE:
-			self.eat(token.type)
-			return Boolean(token)
-		elif token.type == LBRACKET:
-			return self.list_literal()
-		elif self.current_token.type == KEYWORD_C or self.current_token.type == LPAREN:
-			lexer_pos_backup = self.lexer.pos
-			lexer_current_char_backup = self.lexer.current_char
-			parser_current_token_backup = self.current_token
-			is_curried = False
+            self.eat(ARROW)
+            type_token = self.current_token
+            self.eat(type_token.type)
+            node = TypeCast(node, type_token)
+        return node
+    
+    def call_or_index_expression(self):  # Handles both indexing and function calls as postfix
+        """
+        Parses a primary expression, potentially followed by zero or more index accesses or function calls.
+        call_or_index_expression ::= primary (LBRACKET expression RBRACKET | LPAREN (expression (COMMA expression)*)? RPAREN)*
+        """
+        node = self.primary()  # Start with a primary (variable, literal, lambda, etc.)
+        while self.current_token.type in (LBRACKET, LPAREN):
+            if self.current_token.type == LBRACKET:  # It's an index access
+                self.eat(LBRACKET)
+                index_expr = self.expression()
+                self.eat(RBRACKET)
+                node = IndexAccess(node, index_expr)
+            elif self.current_token.type == LPAREN:  # It's a function call
+                self.eat(LPAREN)
+                args = []
+                if self.current_token.type != RPAREN:  # Check if there are arguments
+                    args.append(self.expression())
+                    while self.current_token.type == COMMA:
+                        self.eat(COMMA)
+                        args.append(self.expression())
+                self.eat(RPAREN)
+                node = Call(node, args)  # The node here is the function being called (e.g., Var('square'))
+        return node
+    
+    def primary(self):
+        """
+        Parses the highest precedence elements: numbers, variables, strings, booleans, list literals, lambda expressions, or parenthesized expressions.
+        primary ::= INTEGER | IDENTIFIER | STRING | BOOLEAN | ListLiteral | Lambda | LPAREN expression RPAREN
+        """
+        token = self.current_token
+        if token.type == KEYWORD_IF:
+            return self.if_expression()
+        if token.type in (KEYWORD_LEN, KEYWORD_HEAD, KEYWORD_TAIL, KEYWORD_ABS, KEYWORD_MIN, KEYWORD_MAX, KEYWORD_CLAMP):
+            return self.builtin_call()
+        if token.type == INTEGER:
+            self.eat(INTEGER)
+            return Num(token)
+        elif token.type == IDENTIFIER:
+            self.eat(IDENTIFIER)
+            return Var(token)
+        elif token.type == STRING:
+            self.eat(STRING)
+            return String(token)
+        elif token.type == KEYWORD_TRUE or token.type == KEYWORD_FALSE:
+            self.eat(token.type)
+            return Boolean(token)
+        elif token.type == LBRACKET:
+            return self.list_literal()
+        elif self.current_token.type == KEYWORD_C or self.current_token.type == LPAREN:
+            lexer_pos_backup = self.lexer.pos
+            lexer_current_char_backup = self.lexer.current_char
+            parser_current_token_backup = self.current_token
+            is_curried = False
 
-			if self.current_token.type == KEYWORD_C:
-				is_curried = True
-				self.eat(KEYWORD_C)
+            if self.current_token.type == KEYWORD_C:
+                is_curried = True
+                self.eat(KEYWORD_C)
 
-			if self.current_token.type == LPAREN:
-				self.eat(LPAREN)
-				if self.current_token.type == IDENTIFIER or self.current_token.type == RPAREN:
-					if self.current_token.type == IDENTIFIER:
-						self.eat(IDENTIFIER)
-						while self.current_token.type == COMMA:
-							self.eat(COMMA)
-							self.eat(IDENTIFIER)
-					self.eat(RPAREN)
-					if self.current_token.type == ASSIGN:
-						self.lexer.pos = lexer_pos_backup
-						self.lexer.current_char = lexer_current_char_backup
-						self.current_token = parser_current_token_backup
-						return self.lambda_expression()
-				# restore and treat as parenthesized expression
-				self.lexer.pos = lexer_pos_backup
-				self.lexer.current_char = lexer_current_char_backup
-				self.current_token = parser_current_token_backup
-				self.eat(LPAREN)
-				node = self.expression()
-				self.eat(RPAREN)
-				return node
-			else:
-				if is_curried:
-					self.error("Expected '(' after 'c' for curried lambda.")
-				self.error("Expected integer, identifier, string, boolean, list, lambda, or '('")
-		else:
-			self.error("Expected integer, identifier, string, boolean, list, lambda, or '('")
-	
-	def list_literal(self):
-		"""
-		Parses a list literal.
-		list_literal ::= LBRACKET (expression (COMMA expression)*)? RBRACKET
-		"""
-		self.eat(LBRACKET)
-		elements = []
-		if self.current_token.type != RBRACKET:
-			elements.append(self.expression())
-			while self.current_token.type == COMMA:
-				self.eat(COMMA)
-				elements.append(self.expression())
-		self.eat(RBRACKET)
-		return ListLiteral(elements)
-	
-	def lambda_expression(self):
-		"""
-		Parses a lambda expression.
-		lambda_expression ::= (KEYWORD_C)? LPAREN (IDENTIFIER (COMMA IDENTIFIER)*)? RPAREN ASSIGN (expression | LBRACE (statement (SEMICOLON statement)*)* RBRACE)
-		"""
-		is_curried = False
-		if self.current_token.type == KEYWORD_C:
-			is_curried = True
-			self.eat(KEYWORD_C)
-		
-		self.eat(LPAREN)
-		params = []
-		if self.current_token.type == IDENTIFIER:
-			params.append(self.variable())
-			while self.current_token.type == COMMA:
-				self.eat(COMMA)
-				params.append(self.variable())
-		self.eat(RPAREN)
-		self.eat(ASSIGN)  # The 'transfer' arrow for lambda body
-		
-		body = None
-		if self.current_token.type == LBRACE:  # Check for block body
-			self.eat(LBRACE)
-			body_statements = []
-			while self.current_token.type != RBRACE:
-				body_statements.append(self.statement())
-				while self.current_token.type == SEMICOLON:
-					self.eat(SEMICOLON)
-					if self.current_token.type != RBRACE and self.current_token.type != EOF:
-						body_statements.append(self.statement())
-			self.eat(RBRACE)
-			body = Program(body_statements)	 # Body is a Program node
-		else:
-			body = self.expression()  # Body is a single expression
-		
-		return Lambda(params, body, is_curried)
-	
-	def if_expression(self):
-		"""Parses an if expression with optional else/elif branches."""
-		self.eat(KEYWORD_IF)
-		condition = self.expression()
-		self.eat(ARROW)
-		if self.current_token.type == LBRACE:
-			self.eat(LBRACE)
-			body_statements = []
-			while self.current_token.type != RBRACE:
-				body_statements.append(self.statement())
-				while self.current_token.type == SEMICOLON:
-					self.eat(SEMICOLON)
-					if self.current_token.type != RBRACE and self.current_token.type != EOF:
-						body_statements.append(self.statement())
-			self.eat(RBRACE)
-			then_branch = Program(body_statements)
-		else:
-			then_branch = self.expression()
-		
-		else_branch = None
-		if self.current_token.type == KEYWORD_ELSE:
-			self.eat(KEYWORD_ELSE)
-			if self.current_token.type == KEYWORD_IF:
-				else_branch = self.if_expression()
-			else:
-				if self.current_token.type == LBRACE:
-					self.eat(LBRACE)
-					body_statements = []
-					while self.current_token.type != RBRACE:
-						body_statements.append(self.statement())
-						while self.current_token.type == SEMICOLON:
-							self.eat(SEMICOLON)
-							if self.current_token.type != RBRACE and self.current_token.type != EOF:
-								body_statements.append(self.statement())
-					self.eat(RBRACE)
-					else_branch = Program(body_statements)
-				else:
-					else_branch = self.expression()
-		
-		return IfExpression(condition, then_branch, else_branch)
-	
-	def variable(self):
-		"""Parses a variable (identifier)."""
-		token = self.current_token
-		self.eat(IDENTIFIER)
-		return Var(token)
+            if self.current_token.type == LPAREN:
+                self.eat(LPAREN)
+                if self.current_token.type == IDENTIFIER or self.current_token.type == RPAREN:
+                    if self.current_token.type == IDENTIFIER:
+                        self.eat(IDENTIFIER)
+                        while self.current_token.type == COMMA:
+                            self.eat(COMMA)
+                            self.eat(IDENTIFIER)
+                    self.eat(RPAREN)
+                    if self.current_token.type == ASSIGN:
+                        self.lexer.pos = lexer_pos_backup
+                        self.lexer.current_char = lexer_current_char_backup
+                        self.current_token = parser_current_token_backup
+                        return self.lambda_expression()
+                # restore and treat as parenthesized expression
+                self.lexer.pos = lexer_pos_backup
+                self.lexer.current_char = lexer_current_char_backup
+                self.current_token = parser_current_token_backup
+                self.eat(LPAREN)
+                node = self.expression()
+                self.eat(RPAREN)
+                return node
+            else:
+                if is_curried:
+                    self.error("Expected '(' after 'c' for curried lambda.")
+                self.error("Expected integer, identifier, string, boolean, list, lambda, or '('")
+        else:
+            self.error("Expected integer, identifier, string, boolean, list, lambda, or '('")
+    
+    def list_literal(self):
+        """
+        Parses a list literal.
+        list_literal ::= LBRACKET (expression (COMMA expression)*)? RBRACKET
+        """
+        self.eat(LBRACKET)
+        elements = []
+        if self.current_token.type != RBRACKET:
+            elements.append(self.expression())
+            while self.current_token.type == COMMA:
+                self.eat(COMMA)
+                elements.append(self.expression())
+        self.eat(RBRACKET)
+        return ListLiteral(elements)
+
+    def builtin_call(self):
+        token = self.current_token
+        self.eat(token.type)
+
+        args = []
+        if self.current_token.type == LPAREN:
+            self.eat(LPAREN)
+            if self.current_token.type != RPAREN:
+                args.append(self.expression())
+                while self.current_token.type == COMMA:
+                    self.eat(COMMA)
+                    args.append(self.expression())
+            self.eat(RPAREN)
+        else:
+            args.append(self.expression())
+            while self.current_token.type == COMMA:
+                self.eat(COMMA)
+                args.append(self.expression())
+
+        func_token = Token(IDENTIFIER, token.value)
+        return Call(Var(func_token), args)
+    
+    def lambda_expression(self):
+        """
+        Parses a lambda expression.
+        lambda_expression ::= (KEYWORD_C)? LPAREN (IDENTIFIER (COMMA IDENTIFIER)*)? RPAREN ASSIGN (expression | LBRACE (statement (SEMICOLON statement)*)* RBRACE)
+        """
+        is_curried = False
+        if self.current_token.type == KEYWORD_C:
+            is_curried = True
+            self.eat(KEYWORD_C)
+        
+        self.eat(LPAREN)
+        params = []
+        if self.current_token.type == IDENTIFIER:
+            params.append(self.variable())
+            while self.current_token.type == COMMA:
+                self.eat(COMMA)
+                params.append(self.variable())
+        self.eat(RPAREN)
+        self.eat(ASSIGN)  # The 'transfer' arrow for lambda body
+        
+        body = None
+        if self.current_token.type == LBRACE:  # Check for block body
+            self.eat(LBRACE)
+            body_statements = []
+            while self.current_token.type != RBRACE:
+                body_statements.append(self.statement())
+                while self.current_token.type == SEMICOLON:
+                    self.eat(SEMICOLON)
+                    if self.current_token.type != RBRACE and self.current_token.type != EOF:
+                        body_statements.append(self.statement())
+            self.eat(RBRACE)
+            body = Program(body_statements)  # Body is a Program node
+        else:
+            body = self.expression()  # Body is a single expression
+        
+        return Lambda(params, body, is_curried)
+    
+    def if_expression(self):
+        """Parses an if expression with optional else/elif branches."""
+        self.eat(KEYWORD_IF)
+        condition = self.expression()
+        self.eat(ARROW)
+        if self.current_token.type == LBRACE:
+            self.eat(LBRACE)
+            body_statements = []
+            while self.current_token.type != RBRACE:
+                body_statements.append(self.statement())
+                while self.current_token.type == SEMICOLON:
+                    self.eat(SEMICOLON)
+                    if self.current_token.type != RBRACE and self.current_token.type != EOF:
+                        body_statements.append(self.statement())
+            self.eat(RBRACE)
+            then_branch = Program(body_statements)
+        else:
+            then_branch = self.expression()
+        
+        else_branch = None
+        if self.current_token.type == KEYWORD_ELSE:
+            self.eat(KEYWORD_ELSE)
+            if self.current_token.type == KEYWORD_IF:
+                else_branch = self.if_expression()
+            else:
+                if self.current_token.type == LBRACE:
+                    self.eat(LBRACE)
+                    body_statements = []
+                    while self.current_token.type != RBRACE:
+                        body_statements.append(self.statement())
+                        while self.current_token.type == SEMICOLON:
+                            self.eat(SEMICOLON)
+                            if self.current_token.type != RBRACE and self.current_token.type != EOF:
+                                body_statements.append(self.statement())
+                    self.eat(RBRACE)
+                    else_branch = Program(body_statements)
+                else:
+                    else_branch = self.expression()
+        
+        return IfExpression(condition, then_branch, else_branch)
+    
+    def variable(self):
+        """Parses a variable (identifier)."""
+        token = self.current_token
+        self.eat(IDENTIFIER)
+        return Var(token)

--- a/plank/tests/test_interpreter.py
+++ b/plank/tests/test_interpreter.py
@@ -71,6 +71,22 @@ class PlankTest(unittest.TestCase):
             Case("lst <- list; out <- lst[1]", "2", "[1, 2, 3]"),
             Case("out <- ('123' -> int) + 1", "124"),
         ],
+        "builtins": [
+            Case("out <- len([1, 2, 3])", 3),
+            Case("out <- len [1, 2, 3]", 3),
+            Case("out <- head([10,20,30])", 10),
+            Case("out <- head [10,20,30]", 10),
+            Case("out <- tail([1,2,3])", "[2, 3]"),
+            Case("out <- tail [1,2,3]", "[2, 3]"),
+            Case("out <- abs(-5)", 5),
+            Case("out <- abs -5", 5),
+            Case("out <- min(3, 7)", 3),
+            Case("out <- min 3, 7", 3),
+            Case("out <- max(3, 7)", 7),
+            Case("out <- max 3, 7", 7),
+            Case("out <- clamp(5, 0, 10)", 5),
+            Case("out <- clamp 5, 0, 10", 5),
+        ],
     }
 
     def test_sections(self):

--- a/plank/token_types.py
+++ b/plank/token_types.py
@@ -4,72 +4,79 @@ from enum import Enum, auto
 
 
 class TokenType(Enum):
-	"""Enumeration of all token types."""
-	
-	EOF = auto()  # End of File
-	IDENTIFIER = auto()  # Variable names (e.g., 'a', 'b', 'result')
-	INTEGER = auto()  # Integer literals (e.g., '10', '42')
-	STRING = auto()	 # String literals (e.g., '"hello"', '" "')
-	
-	# Arithmetic Operators
-	PLUS = auto()  # '+'
-	MINUS = auto()	# '-'
-	MULTIPLY = auto()  # '*'
-	DIVIDE = auto()	 # '/'
-	EXPONENT = auto()  # '**'
-	FLOOR_DIVIDE = auto()  # '//'
-	
-	# Assignment and Keywords
-	ASSIGN = auto()	 # '<-'
-	KEYWORD_INT = auto()  # 'int' (type)
-	KEYWORD_STRING = auto()	 # 'string' (type)
-	KEYWORD_BOOL = auto()  # 'bool' (type)
-	KEYWORD_LIST = auto()  # 'list' (type)
-	KEYWORD_OUT = auto()  # 'out' (for output statement)
-	
-	# For Loop Keywords and Operators
-	KEYWORD_FOR = auto()  # 'for'
-	RANGE_OP = auto()  # '..'
-	ARROW = auto()	# '->'
-	
-	# Augmented Assignment Operators
-	PLUS_ASSIGN = auto()  # '+<-'
-	MINUS_ASSIGN = auto()  # '-<-'
-	MULTIPLY_ASSIGN = auto()  # '*<-'
-	DIVIDE_ASSIGN = auto()	# '/<-'
-	EXPONENT_ASSIGN = auto()  # '**<-'
-	FLOOR_DIVIDE_ASSIGN = auto()  # '//<-'
-	
-	# Boolean Literals and Logical Operators
-	KEYWORD_TRUE = auto()  # 'true'
-	KEYWORD_FALSE = auto()	# 'false'
-	KEYWORD_AND = auto()  # 'and'
-	KEYWORD_OR = auto()  # 'or'
-	KEYWORD_NOT = auto()  # 'not'
-	KEYWORD_WHILE = auto()	# 'while'
-	KEYWORD_IF = auto()  # 'if'
-	KEYWORD_ELSE = auto()  # 'else'
-	KEYWORD_C = auto()  # 'c' for curried functions
-	
-	# Comparison Operators
-	EQ = auto()  # '=='
-	NEQ = auto()  # '!='
-	LT = auto()  # '<'
-	GT = auto()  # '>'
-	LTE = auto()  # '<='
-	GTE = auto()  # '>='
-	
-	# Punctuation
-	COMMA = auto()	# ','
-	LPAREN = auto()	 # '('
-	RPAREN = auto()	 # ')'
-	LBRACE = auto()	 # '{'
-	RBRACE = auto()	 # '}'
-	SEMICOLON = auto()  # ';'
-	
-	# List Punctuation
-	LBRACKET = auto()  # '['
-	RBRACKET = auto()  # ']'
+    """Enumeration of all token types."""
+    
+    EOF = auto()  # End of File
+    IDENTIFIER = auto()  # Variable names (e.g., 'a', 'b', 'result')
+    INTEGER = auto()  # Integer literals (e.g., '10', '42')
+    STRING = auto()  # String literals (e.g., '"hello"', '" "')
+    
+    # Arithmetic Operators
+    PLUS = auto()  # '+'
+    MINUS = auto()  # '-'
+    MULTIPLY = auto()  # '*'
+    DIVIDE = auto()  # '/'
+    EXPONENT = auto()  # '**'
+    FLOOR_DIVIDE = auto()  # '//'
+    
+    # Assignment and Keywords
+    ASSIGN = auto()  # '<-'
+    KEYWORD_INT = auto()  # 'int' (type)
+    KEYWORD_STRING = auto()  # 'string' (type)
+    KEYWORD_BOOL = auto()  # 'bool' (type)
+    KEYWORD_LIST = auto()  # 'list' (type)
+    KEYWORD_OUT = auto()  # 'out' (for output statement)
+    
+    # For Loop Keywords and Operators
+    KEYWORD_FOR = auto()  # 'for'
+    RANGE_OP = auto()  # '..'
+    ARROW = auto()  # '->'
+    
+    # Augmented Assignment Operators
+    PLUS_ASSIGN = auto()  # '+<-'
+    MINUS_ASSIGN = auto()  # '-<-'
+    MULTIPLY_ASSIGN = auto()  # '*<-'
+    DIVIDE_ASSIGN = auto()  # '/<-'
+    EXPONENT_ASSIGN = auto()  # '**<-'
+    FLOOR_DIVIDE_ASSIGN = auto()  # '//<-'
+    
+    # Boolean Literals and Logical Operators
+    KEYWORD_TRUE = auto()  # 'true'
+    KEYWORD_FALSE = auto()  # 'false'
+    KEYWORD_AND = auto()  # 'and'
+    KEYWORD_OR = auto()  # 'or'
+    KEYWORD_NOT = auto()  # 'not'
+    KEYWORD_WHILE = auto()  # 'while'
+    KEYWORD_IF = auto()  # 'if'
+    KEYWORD_ELSE = auto()  # 'else'
+    KEYWORD_C = auto()  # 'c' for curried functions
+    KEYWORD_LEN = auto()  # 'len'
+    KEYWORD_HEAD = auto()  # 'head'
+    KEYWORD_TAIL = auto()  # 'tail'
+    KEYWORD_ABS = auto()  # 'abs'
+    KEYWORD_MIN = auto()  # 'min'
+    KEYWORD_MAX = auto()  # 'max'
+    KEYWORD_CLAMP = auto()  # 'clamp'
+    
+    # Comparison Operators
+    EQ = auto()  # '=='
+    NEQ = auto()  # '!='
+    LT = auto()  # '<'
+    GT = auto()  # '>'
+    LTE = auto()  # '<='
+    GTE = auto()  # '>='
+    
+    # Punctuation
+    COMMA = auto()  # ','
+    LPAREN = auto()  # '('
+    RPAREN = auto()  # ')'
+    LBRACE = auto()  # '{'
+    RBRACE = auto()  # '}'
+    SEMICOLON = auto()  # ';'
+    
+    # List Punctuation
+    LBRACKET = auto()  # '['
+    RBRACKET = auto()  # ']'
 
 
 # Export individual names for backwards compatibility


### PR DESCRIPTION
## Summary
- implement builtin functions `len`, `head`, `tail`, `abs`, `min`, `max`, and `clamp`
- allow calling these builtins without parentheses
- add support for calling plain Python callables
- update lexer and parser to recognize builtin keywords
- update tests to cover builtin behaviours

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f73cf3bc832795452b0555b7eef4