### PR TITLE
Implement comments in lexer

### DIFF
--- a/plank/lexer.py
+++ b/plank/lexer.py
@@ -114,9 +114,16 @@ class Lexer:
                 return False
         
         def skip_whitespace(self):
-                """Skip over any whitespace characters."""
-                while self.current_char is not None and self.current_char.isspace():
-                        self.advance()
+                """Skip over whitespace and comments."""
+                while self.current_char is not None:
+                        if self.current_char.isspace():
+                                self.advance()
+                                continue
+                        if self.current_char == '#':
+                                while self.current_char is not None and self.current_char != '\n':
+                                        self.advance()
+                                continue
+                        break
         
         def integer(self):
                 """Parse an integer literal from the input."""

--- a/plank/tests/test_interpreter.py
+++ b/plank/tests/test_interpreter.py
@@ -103,6 +103,10 @@ class PlankTest(unittest.TestCase):
             Case("out <- zip([1,2], [3,4])[1][1]", 4),
             Case("out <- enumerate(['a','b'])[1][0]", 1),
         ],
+        "comments": [
+            Case("a <- 1 # assign a\nout <- a", 1),
+            Case("# only comment line\nout <- 2", 2),
+        ],
     }
 
     def test_sections(self):


### PR DESCRIPTION
## Summary
- support `#` comments in the lexer
- ignore comment text until end of line when tokenizing
- add interpreter tests showing comments are skipped

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446afab6c48327a9a6d1f634cf630f