### PR TITLE
Add modulus operator with assignment support

### DIFF
--- a/plank/interpreter.py
+++ b/plank/interpreter.py
@@ -299,6 +299,10 @@ class Interpreter:
                 if right_val == 0:
                     raise Exception("Runtime error: Division by zero")
                 return left_val / right_val
+            case TokenType.MODULUS:
+                if right_val == 0:
+                    raise Exception("Runtime error: Division by zero")
+                return left_val % right_val
             case TokenType.FLOOR_DIVIDE:
                 if right_val == 0:
                     raise Exception("Runtime error: Division by zero")
@@ -440,6 +444,9 @@ class Interpreter:
         elif node.op.type == DIVIDE_ASSIGN:
             if expr_val == 0: raise Exception("Runtime error: Division by zero")
             new_val = current_val / expr_val
+        elif node.op.type == MODULUS_ASSIGN:
+            if expr_val == 0: raise Exception("Runtime error: Division by zero")
+            new_val = current_val % expr_val
         elif node.op.type == FLOOR_DIVIDE_ASSIGN:
             if expr_val == 0: raise Exception("Runtime error: Division by zero")
             new_val = current_val // expr_val

--- a/plank/lexer.py
+++ b/plank/lexer.py
@@ -62,6 +62,7 @@ class Lexer:
                 '**': EXPONENT,
                 '//<-': FLOOR_DIVIDE_ASSIGN,
                 '/<-': DIVIDE_ASSIGN,
+                '%<-': MODULUS_ASSIGN,
                 '//': FLOOR_DIVIDE,
                 '<-': ASSIGN,
                 '->': ARROW,
@@ -77,6 +78,7 @@ class Lexer:
         SINGLE_OPS = {
                 '*': MULTIPLY,
                 '/': DIVIDE,
+                '%': MODULUS,
                 '<': LT,
                 '>': GT,
                 '-': MINUS,

--- a/plank/parser.py
+++ b/plank/parser.py
@@ -143,8 +143,8 @@ class Parser:
                     self.current_token = parser_current_token_backup
                     return self.assignment_statement()
                 elif self.current_token.type in (
-                        PLUS_ASSIGN, MINUS_ASSIGN, MULTIPLY_ASSIGN, DIVIDE_ASSIGN, EXPONENT_ASSIGN,
-                        FLOOR_DIVIDE_ASSIGN):
+                        PLUS_ASSIGN, MINUS_ASSIGN, MULTIPLY_ASSIGN, DIVIDE_ASSIGN, MODULUS_ASSIGN,
+                        EXPONENT_ASSIGN, FLOOR_DIVIDE_ASSIGN):
                     self.lexer.pos = lexer_pos_backup
                     self.lexer.current_char = lexer_current_char_backup
                     self.current_token = parser_current_token_backup
@@ -334,14 +334,16 @@ class Parser:
         return node
     
     def multiplicative_expression(self):
-        """Handles '*', '/', '//' operators."""
+        """Handles '*', '/', '%', '//' operators."""
         node = self.exponentiation_expression()
-        while self.current_token.type in (MULTIPLY, DIVIDE, FLOOR_DIVIDE):
+        while self.current_token.type in (MULTIPLY, DIVIDE, MODULUS, FLOOR_DIVIDE):
             token = self.current_token
             if token.type == MULTIPLY:
                 self.eat(MULTIPLY)
             elif token.type == DIVIDE:
                 self.eat(DIVIDE)
+            elif token.type == MODULUS:
+                self.eat(MODULUS)
             elif token.type == FLOOR_DIVIDE:
                 self.eat(FLOOR_DIVIDE)
             node = BinOp(left=node, op=token, right=self.exponentiation_expression())

--- a/plank/tests/test_interpreter.py
+++ b/plank/tests/test_interpreter.py
@@ -33,6 +33,8 @@ class PlankTest(unittest.TestCase):
         "arithmetic": [
             Case("a <- 10; b <- 5; out <- a + b", 15),
             Case("a <- 0; a +<- 2; out <- a", 2),
+            Case("out <- 10 % 3", 1),
+            Case("a <- 7; a %<- 4; out <- a", 3),
         ],
         "strings": [
             Case("out <- 'Hello' <- ' ' <- 'World!'", "Hello World!"),

--- a/plank/token_types.py
+++ b/plank/token_types.py
@@ -16,6 +16,7 @@ class TokenType(Enum):
     MINUS = auto()  # '-'
     MULTIPLY = auto()  # '*'
     DIVIDE = auto()  # '/'
+    MODULUS = auto()  # '%'
     EXPONENT = auto()  # '**'
     FLOOR_DIVIDE = auto()  # '//'
     
@@ -37,6 +38,7 @@ class TokenType(Enum):
     MINUS_ASSIGN = auto()  # '-<-'
     MULTIPLY_ASSIGN = auto()  # '*<-'
     DIVIDE_ASSIGN = auto()  # '/<-'
+    MODULUS_ASSIGN = auto()  # '%<-'
     EXPONENT_ASSIGN = auto()  # '**<-'
     FLOOR_DIVIDE_ASSIGN = auto()  # '//<-'
     


### PR DESCRIPTION
## Summary
- introduce `MODULUS` and `MODULUS_ASSIGN` tokens
- update lexer tables for `%` and `%<-`
- support modulus in parser rules
- implement runtime logic for `%` and `%<-`
- test modulus operator and augmented assignment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446b00a8f48327929541ef083d4c97