### PR TITLE
Add return statements for lambda blocks

### DIFF
--- a/plank/ast_nodes.py
+++ b/plank/ast_nodes.py
@@ -163,6 +163,11 @@ class ContinueStatement(AST):
 
 
 @dataclass(slots=True)
+class Return(AST):
+        value: AST | None = None
+
+
+@dataclass(slots=True)
 class TypeCast(AST):
         expr: AST
         type_token: Token

--- a/plank/interpreter.py
+++ b/plank/interpreter.py
@@ -13,6 +13,11 @@ class ContinueSignal(Exception):
     pass
 
 
+class ReturnSignal(Exception):
+    def __init__(self, value):
+        self.value = value
+
+
 # --- Interpreter ---
 # Represents a callable function created from a Lambda AST node.
 class Callable:
@@ -61,10 +66,16 @@ class Interpreter:
         result = None
         try:
             if isinstance(func_obj.body, Program):
-                for statement in func_obj.body.statements:
-                    result = self.visit(statement)
+                try:
+                    for statement in func_obj.body.statements:
+                        result = self.visit(statement)
+                except ReturnSignal as rs:
+                    result = rs.value
             else:
-                result = self.visit(func_obj.body)
+                try:
+                    result = self.visit(func_obj.body)
+                except ReturnSignal as rs:
+                    result = rs.value
         finally:
             self.scopes = original_scopes
         return result
@@ -608,6 +619,10 @@ class Interpreter:
 
     def visit_ContinueStatement(self, node):
         raise ContinueSignal()
+
+    def visit_Return(self, node):
+        value = self.visit(node.value) if node.value is not None else None
+        raise ReturnSignal(value)
     
     def interpret(self):
         """Start the interpretation process by parsing the program and visiting its AST."""

--- a/plank/lexer.py
+++ b/plank/lexer.py
@@ -35,6 +35,7 @@ class Lexer:
                 'else': (KEYWORD_ELSE, 'else'),
                 'break': (KEYWORD_BREAK, 'break'),
                 'continue': (KEYWORD_CONTINUE, 'continue'),
+                'return': (KEYWORD_RETURN, 'return'),
                 'c': (KEYWORD_C, 'c'),
                 'len': (KEYWORD_LEN, 'len'),
                 'head': (KEYWORD_HEAD, 'head'),

--- a/plank/parser.py
+++ b/plank/parser.py
@@ -56,6 +56,8 @@ class Parser:
         elif self.current_token.type == KEYWORD_CONTINUE:
             self.eat(KEYWORD_CONTINUE)
             return ContinueStatement()
+        elif self.current_token.type == KEYWORD_RETURN:
+            return self.return_statement()
         elif self.current_token.type == LPAREN:
             # Look ahead for 'for' or 'while' to distinguish loops from expressions
             lexer_pos_backup = self.lexer.pos
@@ -237,6 +239,14 @@ class Parser:
         self.eat(op_token.type)  # Consume the augmented assignment operator
         expr_node = self.expression()
         return AugmentedAssign(var_node, op_token, expr_node)
+
+    def return_statement(self):
+        """Parses a return statement with an optional expression."""
+        self.eat(KEYWORD_RETURN)
+        expr = None
+        if self.current_token.type not in (SEMICOLON, RBRACE, EOF):
+            expr = self.expression()
+        return Return(expr)
     
     def for_statement(self):
         """

--- a/plank/tests/test_interpreter.py
+++ b/plank/tests/test_interpreter.py
@@ -63,6 +63,8 @@ class PlankTest(unittest.TestCase):
             Case("closure_example <- (y) <- (x) <- x + y; f <- closure_example(10); out <- f(5); out <- '\\n'", 15),
             Case("adder_block <- (x) <- { y <- x + 1; y }; out <- adder_block(4); out <- '\\n'", 5),
             Case("curried_sum <- c(a, b) <- a + b; add_five <- curried_sum(5); out <- add_five(3); out <- '\\n'", 8),
+            Case("ret <- (x) <- { return x * 2; x * 3 }; out <- ret(4); out <- '\n'", 8),
+            Case("sign <- (x) <- { if x > 0 -> { return 1 }; if x < 0 -> { return -1 }; 0 }; out <- sign(-5); out <- '\n'", -1),
         ],
         "conditionals": [
             Case("x <- 5; result <- if x < 0 -> { 'negative' } else if x == 0 -> { 'zero' } else { 'positive' }; out <- result", "positive"),

--- a/plank/token_types.py
+++ b/plank/token_types.py
@@ -52,6 +52,7 @@ class TokenType(Enum):
     KEYWORD_ELSE = auto()  # 'else'
     KEYWORD_BREAK = auto()  # 'break'
     KEYWORD_CONTINUE = auto()  # 'continue'
+    KEYWORD_RETURN = auto()  # 'return'
     KEYWORD_C = auto()  # 'c' for curried functions
     KEYWORD_LEN = auto()  # 'len'
     KEYWORD_HEAD = auto()  # 'head'


### PR DESCRIPTION
## Summary
- add KEYWORD_RETURN token and Return AST node
- parse `return` statements
- support early returns in lambdas
- test early returns in lambdas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446dd4118c8327b4e713f87dc199a7