### PR TITLE
Add function definitions and recursion

### DIFF
--- a/plank/ast_nodes.py
+++ b/plank/ast_nodes.py
@@ -88,9 +88,16 @@ class ListAssign(AST):
 
 @dataclass(slots=True)
 class Lambda(AST):
-	params: list
-	body: AST
-	is_curried: bool = False
+        params: list
+        body: AST
+        is_curried: bool = False
+
+
+@dataclass(slots=True)
+class FunctionDef(AST):
+        name: Var
+        params: list
+        body: Program
 
 
 @dataclass(slots=True)

--- a/plank/interpreter.py
+++ b/plank/interpreter.py
@@ -420,6 +420,13 @@ class Interpreter:
         # This allows the lambda to access variables from where it was defined.
         closure_env = list(self.scopes)  # Create a copy of the scope stack
         return Callable(node.params, node.body, closure_env, is_curried=node.is_curried)
+
+    def visit_FunctionDef(self, node):
+        """Create a named function and store it in the current scope."""
+        closure_env = list(self.scopes)
+        func = Callable(node.params, node.body, closure_env)
+        self.assign_variable(node.name.value, func)
+        return func
     
     def visit_Call(self, node):
         """

--- a/plank/lexer.py
+++ b/plank/lexer.py
@@ -36,6 +36,7 @@ class Lexer:
                 'break': (KEYWORD_BREAK, 'break'),
                 'continue': (KEYWORD_CONTINUE, 'continue'),
                 'return': (KEYWORD_RETURN, 'return'),
+                'fn': (KEYWORD_FN, 'fn'),
                 'c': (KEYWORD_C, 'c'),
                 'len': (KEYWORD_LEN, 'len'),
                 'head': (KEYWORD_HEAD, 'head'),

--- a/plank/parser.py
+++ b/plank/parser.py
@@ -58,6 +58,8 @@ class Parser:
             return ContinueStatement()
         elif self.current_token.type == KEYWORD_RETURN:
             return self.return_statement()
+        elif self.current_token.type == KEYWORD_FN:
+            return self.function_definition()
         elif self.current_token.type == LPAREN:
             # Look ahead for 'for' or 'while' to distinguish loops from expressions
             lexer_pos_backup = self.lexer.pos
@@ -247,6 +249,30 @@ class Parser:
         if self.current_token.type not in (SEMICOLON, RBRACE, EOF):
             expr = self.expression()
         return Return(expr)
+
+    def function_definition(self):
+        """Parses a function definition."""
+        self.eat(KEYWORD_FN)
+        name = self.variable()
+        self.eat(LPAREN)
+        params = []
+        if self.current_token.type == IDENTIFIER:
+            params.append(self.variable())
+            while self.current_token.type == COMMA:
+                self.eat(COMMA)
+                params.append(self.variable())
+        self.eat(RPAREN)
+        self.eat(ARROW)
+        self.eat(LBRACE)
+        body_statements = []
+        while self.current_token.type != RBRACE:
+            body_statements.append(self.statement())
+            while self.current_token.type == SEMICOLON:
+                self.eat(SEMICOLON)
+                if self.current_token.type != RBRACE and self.current_token.type != EOF:
+                    body_statements.append(self.statement())
+        self.eat(RBRACE)
+        return FunctionDef(name, params, Program(body_statements))
     
     def for_statement(self):
         """

--- a/plank/tests/test_interpreter.py
+++ b/plank/tests/test_interpreter.py
@@ -68,6 +68,10 @@ class PlankTest(unittest.TestCase):
             Case("ret <- (x) <- { return x * 2; x * 3 }; out <- ret(4); out <- '\n'", 8),
             Case("sign <- (x) <- { if x > 0 -> { return 1 }; if x < 0 -> { return -1 }; 0 }; out <- sign(-5); out <- '\n'", -1),
         ],
+        "function_defs": [
+            Case("fn inc(x) -> { return x + 1 }; out <- inc(5); out <- '\n'", 6),
+            Case("fn fact(n) -> { if n == 0 -> { return 1 }; return n * fact(n - 1) }; out <- fact(5); out <- '\n'", 120),
+        ],
         "conditionals": [
             Case("x <- 5; result <- if x < 0 -> { 'negative' } else if x == 0 -> { 'zero' } else { 'positive' }; out <- result", "positive"),
         ],

--- a/plank/token_types.py
+++ b/plank/token_types.py
@@ -55,6 +55,7 @@ class TokenType(Enum):
     KEYWORD_BREAK = auto()  # 'break'
     KEYWORD_CONTINUE = auto()  # 'continue'
     KEYWORD_RETURN = auto()  # 'return'
+    KEYWORD_FN = auto()  # 'fn'
     KEYWORD_C = auto()  # 'c' for curried functions
     KEYWORD_LEN = auto()  # 'len'
     KEYWORD_HEAD = auto()  # 'head'


### PR DESCRIPTION
## Summary
- add KEYWORD_FN token and update lexer
- define `FunctionDef` AST node
- parse `fn name(args) -> { ... }` blocks
- interpret function definitions with support for recursion
- test simple and recursive functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844741fa5048327b372507b516fdd68