### PR TITLE
Add import statement support

### DIFF
--- a/plank/ast_nodes.py
+++ b/plank/ast_nodes.py
@@ -131,7 +131,12 @@ class InputStatement(AST):
 
 @dataclass(slots=True)
 class OutputStatement(AST):
-	expressions: list
+        expressions: list
+
+
+@dataclass(slots=True)
+class ImportStatement(AST):
+        path_token: Token
 
 
 @dataclass(slots=True)

--- a/plank/interpreter.py
+++ b/plank/interpreter.py
@@ -4,6 +4,8 @@ import math
 from plank.ast_nodes import *
 from plank.token_types import *
 from plank.token_types import TokenType
+from plank.lexer import Lexer
+from plank.parser import Parser
 
 
 class BreakSignal(Exception):
@@ -42,6 +44,7 @@ class Interpreter:
     def __init__(self, parser=None):
         self.parser = parser
         self.scopes = [{}]  # List of dictionaries, each dict is a scope. Global scope is the first.
+        self.modules = {}
         self._setup_builtins()
 
     def _call_function(self, func_obj, args):
@@ -251,6 +254,7 @@ class Interpreter:
             'range': b_range,
         }
         self.scopes[0].update(builtins)
+        self.builtin_names = set(builtins.keys())
     
     @property
     def current_scope(self):
@@ -530,6 +534,30 @@ class Interpreter:
             raise Exception(f"Runtime error: Unknown augmented assignment operator {node.op.value}")
         
         self.assign_variable(var_name, new_val)  # Use assign_variable
+
+    def visit_ImportStatement(self, node):
+        path = node.path_token.value
+        if not path.endswith('.plank'):
+            path += '.plank'
+        if path in self.modules:
+            module_scope = self.modules[path]
+        else:
+            try:
+                with open(path, 'r') as f:
+                    code = f.read()
+            except FileNotFoundError:
+                raise Exception(f"Runtime error: Cannot find module '{path}'")
+            lexer = Lexer(code)
+            parser = Parser(lexer)
+            child = Interpreter(parser)
+            child.modules = self.modules
+            child.interpret()
+            module_scope = {
+                k: v for k, v in child.scopes[0].items()
+                if k not in child.builtin_names
+            }
+            self.modules[path] = module_scope
+        self.scopes[0].update(module_scope)
     
     def visit_InputStatement(self, node):
         """

--- a/plank/lexer.py
+++ b/plank/lexer.py
@@ -26,6 +26,7 @@ class Lexer:
                 'dict': (KEYWORD_DICT, 'dict'),
                 'set': (KEYWORD_SET, 'set'),
                 'out': (KEYWORD_OUT, 'out'),
+                'import': (KEYWORD_IMPORT, 'import'),
                 'for': (KEYWORD_FOR, 'for'),
                 'true': (KEYWORD_TRUE, True),
                 'false': (KEYWORD_FALSE, False),

--- a/plank/parser.py
+++ b/plank/parser.py
@@ -49,7 +49,9 @@ class Parser:
                       expression_statement
         """
         # Try parsing specific statement types first
-        if self.current_token.type == KEYWORD_OUT:
+        if self.current_token.type == KEYWORD_IMPORT:
+            return self.import_statement()
+        elif self.current_token.type == KEYWORD_OUT:
             return self.output_statement()
         elif self.current_token.type == KEYWORD_BREAK:
             self.eat(KEYWORD_BREAK)
@@ -170,7 +172,15 @@ class Parser:
         # If it's none of the above, it must be an expression statement (e.g., a literal, a function call)
         else:
             return self.expression_statement()
-    
+
+    def import_statement(self):
+        self.eat(KEYWORD_IMPORT)
+        if self.current_token.type != STRING:
+            self.error("Expected string after 'import'")
+        token = self.current_token
+        self.eat(STRING)
+        return ImportStatement(token)
+
     def input_statement(self):
         """
         Parses an input statement.

--- a/plank/tests/test_interpreter.py
+++ b/plank/tests/test_interpreter.py
@@ -136,6 +136,21 @@ class PlankTest(unittest.TestCase):
                         out = output if isinstance(case.expected, str) and case.expected.endswith("\n") else output.rstrip("\n")
                         self.assertEqual(out, expected_str)
 
+    def test_imports(self):
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            lib_path = tmp_path / "lib.plank"
+            use_path = tmp_path / "use_lib.plank"
+            lib_path.write_text("value <- 5\ndouble <- (x) <- x * 2")
+            use_path.write_text(f"import '{lib_path}'\nout <- double(value)")
+
+            code = use_path.read_text()
+            _, output = run(code)
+            self.assertEqual(output, '10')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/plank/token_types.py
+++ b/plank/token_types.py
@@ -30,6 +30,7 @@ class TokenType(Enum):
     KEYWORD_DICT = auto()  # 'dict' (type)
     KEYWORD_SET = auto()  # 'set' (type)
     KEYWORD_OUT = auto()  # 'out' (for output statement)
+    KEYWORD_IMPORT = auto()  # 'import' keyword
     
     # For Loop Keywords and Operators
     KEYWORD_FOR = auto()  # 'for'


### PR DESCRIPTION
## Summary
- support `import` keyword token
- parse ImportStatement that loads another file
- execute imported modules in `Interpreter`
- test importing between plank files using temporary files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844793b9ea48327921408a0511d34e4