### PR TITLE
Add dictionary and set literal tests

### DIFF
--- a/plank/tests/test_interpreter.py
+++ b/plank/tests/test_interpreter.py
@@ -62,6 +62,9 @@ class PlankTest(unittest.TestCase):
         "dicts and sets": [
             Case("d <- {'a': 1, 'b': 2}; out <- d['b']; out <- '\\n'", 2),
             Case("out <- len({1,2,3})", 3),
+            Case("d <- {'x': 10, 'y': 20}; out <- d['x']", 10),
+            Case("key <- 'b'; d <- {'a': 1, 'b': 2}; out <- d[key]", 2),
+            Case("s <- {1,2,2,3}; out <- len(s)", 3),
         ],
         "functions": [
             Case("square <- (x) <- x * x; out <- square(4); out <- '\\n'", 16),


### PR DESCRIPTION
## Summary
- ensure dictionary and set token definitions are present for braces and keywords
- verify the lexer maps the new keywords
- confirm AST nodes exist for DictLiteral and SetLiteral
- show parser support for `{}` literals
- interpreter evaluates these new nodes
- add unit tests for dictionary access and set creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844866178a083279a773fccfd13e045